### PR TITLE
Log what needs to be logged inside of the script

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -150,7 +150,9 @@ match_their_crates() {
 }
 
 patch_and_check_dependent() {
-  match_their_crates "$(basename "$PWD")"
+  local repo_name="$(basename "$PWD")"
+  echo "patching $repo_name at SHA $(git rev-parse --abbrev-ref HEAD)"
+  match_their_crates "$repo_name"
   diener patch --crates-to-patch "$this_repo_dir" "$this_repo_diener_arg" --path "Cargo.toml"
   eval "${COMPANION_CHECK_COMMAND:-cargo check --all-targets --workspace}"
 }


### PR DESCRIPTION
This is more precise, more informational and more readable. Also it means we do not have to change the `.gitlab-ci.yml` pipeline of each single repository if we wanted to change this log line.

replaces the functionality of https://github.com/paritytech/substrate/pull/10076 and https://github.com/paritytech/polkadot/pull/4120