### PR TITLE
Skip merged companions and add back some checks

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -204,7 +204,6 @@ process_pr_description_line() {
         return
       fi
     done
-    companions+=("$repo")
 
     local state closed mergeable ref sha
     read -d '\n' -r state closed mergeable ref sha < <(curl \
@@ -230,6 +229,8 @@ process_pr_description_line() {
     if [ "$mergeable" != "true" ]; then
       die "Github API says $repo#$pr_number is not mergeable"
     fi
+
+    companions+=("$repo")
 
     # Heuristic: assume the companion PR has a common merge ancestor with master
     # in its last N commits.

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -319,14 +319,14 @@ patch_and_check_dependent() {
 
   pushd "$dependent_repo_dir" >/dev/null
 
-  match_dependent_crates "$dependent"
-
   # Update the crates to the latest version. This is for example needed if there
   # was a PR to Substrate which only required a Polkadot companion and Cumulus
   # wasn't yet updated to use the latest commit of Polkadot.
   for update in $update_crates_on_default_branch; do
     cargo update -p "$update"
   done
+
+  match_dependent_crates "$dependent"
 
   for comp in "${dependent_companions[@]}"; do
     echo "Patching $comp companion into $dependent"

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -243,13 +243,11 @@ process_pr_description_line() {
       "$companions_dir/$repo"
     pushd "$companions_dir/$repo" >/dev/null
 
+    # Show what branches we got after cloning the repository
+    git show-ref
+
     # Clone the companion's branch
-    local ref="$(curl \
-        -sSL \
-        -H "Authorization: token $github_api_token" \
-        "$github_api/repos/$org/$repo/pulls/$pr_number" | \
-      jq -e -r ".head.ref"
-    )"
+    echo "Cloning the companion $repo#$pr_number (branch $ref, SHA $sha)"
     git fetch --depth=$merge_ancestor_max_depth origin "pull/$pr_number/head:$ref"
     git checkout "$ref"
 

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -359,11 +359,11 @@ main() {
   # accompanying changes for the code being brought in.
   git fetch --force origin master
   git show-ref origin/master
-  echo "Merge master into $CI_COMMIT_REF_NAME"
+  echo "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
   git merge origin/master \
     --verbose \
     --no-edit \
-    -m "Merge master into $CI_COMMIT_REF_NAME"
+    -m "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
 
   discover_our_crates
 


### PR DESCRIPTION
closes #7 and also adds back some checks overlooked in https://github.com/paritytech/pipeline-scripts/pull/19/files#diff-df602127cd49392d5fb1da82c27351842395a47e788e0c6a77cf52d690ed1d2aL194