### PR TITLE
Update all packages in one go instead of one-by-one

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -313,6 +313,16 @@ process_pr_description() {
   done
 }
 
+update_crates() {
+  local args=()
+
+  for crate in "$@"; do
+    args+=("-p" "$crate")
+  done
+
+  cargo update "${args[@]}"
+}
+
 patch_and_check_dependent() {
   local dependent="$1"
   local dependent_repo_dir="$2"
@@ -322,9 +332,7 @@ patch_and_check_dependent() {
   # Update the crates to the latest version. This is for example needed if there
   # was a PR to Substrate which only required a Polkadot companion and Cumulus
   # wasn't yet updated to use the latest commit of Polkadot.
-  for update in $update_crates_on_default_branch; do
-    cargo update -p "$update"
-  done
+  update_crates $update_crates_on_default_branch
 
   match_dependent_crates "$dependent"
 


### PR DESCRIPTION
~Split `$update_crates_on_default_branch` through shell expansion so that it can be used properly with `cargo -p`.~ Update: I thought there was a problem with `for var in $string` from local testing but it turns out my tests were wrong.

This PR would change the current behavior and make all the packages update in one go instead of one by one. Originally it was created for https://github.com/paritytech/polkadot/pull/4928 but it's not strictly needed.

This change should also "just work" for other existing repositories which are not Polkadot e.g. https://github.com/paritytech/substrate/blob/b2f76e26a9e8cd0d5457058b20bb250d092a16ac/.gitlab-ci.yml#L555