### PR TITLE
Receive CLI arguments as options for check_dependent_project.sh

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -23,27 +23,22 @@ changes.
 set -eu -o pipefail
 shopt -s inherit_errexit
 
-die() {
-  if [ "${1:-}" ]; then
-    >&2 echo "$1"
-  fi
-  exit 1
-}
+. "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
-org="$1"
-this_repo="$2"
-this_repo_diener_arg="$3"
-dependent_repo="$4"
-github_api_token="$5"
-update_crates_on_default_branch="$6"
-extra_dependencies="${7:-}"
+get_arg required --org "$@"; org="$out"
+get_arg required --dependent-repo "$@"; dependent_repo="$out"
+get_arg required --github-api-token "$@"; github_api_token="$out"
+get_arg optional --extra-dependencies "$@"; extra_dependencies="${out:-}"
 
+set -x
 this_repo_dir="$PWD"
+this_repo="$(dirname "$PWD")"
 companions_dir="$this_repo_dir/companions"
 extra_dependencies_dir="$this_repo_dir/extra_dependencies"
 github_api="https://api.github.com"
 org_github_prefix="https://github.com/$org"
 org_crates_prefix="git+$org_github_prefix"
+set +x
 
 our_crates=()
 discover_our_crates() {

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,46 @@
+die() {
+  if [ "${1:-}" ]; then
+    >&2 echo "$1"
+  fi
+  exit 1
+}
+
+get_arg() {
+  local is_required
+  case "$1" in
+    required)
+      is_required=true
+    ;;
+    optional)
+      is_required=false
+    ;;
+    *)
+      die "Invalid is_required argument \"$2\" in get_arg"
+    ;;
+  esac
+  shift
+
+  local option_arg="$1"
+  shift
+
+  unset out
+
+  local get_next_arg
+  for arg in "$@"; do
+    if [ "${get_next_arg:-}" ]; then
+      out="$arg"
+      break
+    # --foo=bar (get the value after '=')
+    elif [ "${arg:0:$(( ${#option_arg} + 1 ))}" == "$option_arg=" ]; then
+      out="${arg:$(( ${#option_arg} + 1 ))}"
+      break
+    # --foo bar (get the next argument)
+    elif [ "$arg" == "$option_arg" ]; then
+      get_next_arg=true
+    fi
+  done
+
+  if [[ ! "${out:-}" && $is_required == true ]]; then
+    die "Argument $option_arg is required, but was not found"
+  fi
+}


### PR DESCRIPTION
close #33 

It will require PRs on all repositories where this script is used, but at least we'll not have to suffer as much when adding new options in the future.

What prompted this effort is the need to add new option for #32.