### PR TITLE
Allow customizable companion refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,37 @@ many repositories) for our CI pipelines.
 # TOC
 
 - [check_dependent_project](#check_dependent_project)
+  - [Usage](#check_dependent_project-usage)
+  - [Explanation](#check_dependent_project-explanation)
   - [Implementation](#check_dependent_project-implementation)
 
 # check_dependent_project <a name="check_dependent_project"></a>
+
+## Usage <a name="check_dependent_project-explanation"></a>
+
+Specify companions in the description of a pull request. For example, if you
+have a pull request which needs a Polkadot companion, say:
+
+```
+polkadot companion: [link]
+```
+
+The above tells the integration checks to test the pull request's branch with
+the specified PR rather than the default branch for that companion's repository.
+
+---
+
+On pull requests **not targetting the master branch** you're able to specify the
+branch directly:
+
+```
+polkadot companion branch: [branch]
+```
+
+The above tells the script to use the specified branch in `${ORG}/polkadot`
+rather than the master branch.
+
+## Explanation <a name="check_dependent_project-explanation"></a>
 
 [check_dependent_project](./check_dependent_project.sh) implements the
 [Companion Build System](https://github.com/paritytech/parity-processbot/issues/327)'s

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ many repositories) for our CI pipelines.
 
 # check_dependent_project <a name="check_dependent_project"></a>
 
-## Usage <a name="check_dependent_project-explanation"></a>
+## Usage <a name="check_dependent_project-usage"></a>
 
 Specify companions in the description of a pull request. For example, if you
 have a pull request which needs a Polkadot companion, say:

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ companion's branch in their description:
 polkadot companion branch: [branch]
 ```
 
-The above tells the script to use the specified branch in `${ORG}/polkadot`
+The above tells the script to use the specified branch from `${ORG}/polkadot`
 rather than the default branch for that companion's repository.
 
-Alternatively, you can also specify a permanent override configuration through
-`--companion-overrides`. Suppose the following:
+Alternatively, it's also possible to provide a permanent override configuration
+through `--companion-overrides`. As an example:
 
 ```bash
 check_dependent_project.sh \
@@ -47,12 +47,12 @@ check_dependent_project.sh \
   "
 ```
 
-The above configures the script to use, for example, the `release-v1.2` Polkadot
-branch for the companion in case the Substrate pull request is **targetting**
-the `polkadot-v1.2` branch - note how the suffix captured from the wildcard
-pattern, namely `1.2` from the pattern `*`, is correlated between those refs.
-This feature exists for release engineering purposes (more context in
-[issue 32](https://github.com/paritytech/pipeline-scripts/issues/32)).
+The above configures the script to use, for instance, the `release-v1.2`
+Polkadot branch for the companion in case the Substrate pull request is
+**targetting** the `polkadot-v1.2` branch - note how the suffix captured from
+the wildcard pattern, namely `1.2` from the pattern `*`, is correlated between
+those refs. This feature exists for release engineering purposes (more context
+in [issue 32](https://github.com/paritytech/pipeline-scripts/issues/32)).
 
 ## Explanation <a name="check_dependent_project-explanation"></a>
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,33 @@ the specified PR rather than the default branch for that companion's repository.
 
 ---
 
-On pull requests **not targetting the master branch** you're able to specify the
-branch directly:
+On pull requests **which don't target master** you're able to specify the
+companion's branch in the pull request's description:
 
 ```
 polkadot companion branch: [branch]
 ```
 
 The above tells the script to use the specified branch in `${ORG}/polkadot`
-rather than the master branch.
+rather than the default branch for that companion's repository.
+
+Alternatively, you can also specify a permanent override configuration through
+`--companion-overrides`. Suppose the following:
+
+```bash
+check_dependent_project.sh \
+  --companion-overrides "
+    substrate: polkadot-v*
+    polkadot: release-v*
+  "
+```
+
+The above configures the script to use, for example, the `release-v1` Polkadot
+branch for the companion in case the Substrate pull request is **targetting**
+the `polkadot-v1` branch - note how the suffix captured from the wildcard
+pattern, namely `1` from the pattern `*`, is correlated between those refs. This
+feature exists for the sake of testing the CI before a release (more context in
+[issue 32](https://github.com/paritytech/pipeline-scripts/issues/32)).
 
 ## Explanation <a name="check_dependent_project-explanation"></a>
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the specified PR rather than the default branch for that companion's repository.
 ---
 
 On pull requests **which don't target master** you're able to specify the
-companion's branch in the pull request's description:
+companion's branch in their description:
 
 ```
 polkadot companion branch: [branch]
@@ -47,11 +47,11 @@ check_dependent_project.sh \
   "
 ```
 
-The above configures the script to use, for example, the `release-v1` Polkadot
+The above configures the script to use, for example, the `release-v1.2` Polkadot
 branch for the companion in case the Substrate pull request is **targetting**
-the `polkadot-v1` branch - note how the suffix captured from the wildcard
-pattern, namely `1` from the pattern `*`, is correlated between those refs. This
-feature exists for the sake of testing the CI before a release (more context in
+the `polkadot-v1.2` branch - note how the suffix captured from the wildcard
+pattern, namely `1.2` from the pattern `*`, is correlated between those refs.
+This feature exists for release engineering purposes (more context in
 [issue 32](https://github.com/paritytech/pipeline-scripts/issues/32)).
 
 ## Explanation <a name="check_dependent_project-explanation"></a>

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -526,6 +526,8 @@ main() {
           continue
         fi
 
+        echo "Detected override $this_repo_override for $this_repo and override $dependent_repo_override for $dependent_repo"
+
         local base_ref_prefix="${this_repo_override_prefix:-$this_repo_override}"
         if [ "${pr_base_ref[$this_repo]:0:${#base_ref_prefix}}" != "$base_ref_prefix" ]; then
           continue

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -356,15 +356,14 @@ process_pr_description() {
 
   echo "Processing PR $repo#$pr_number"
 
-  local has_read_base_ref base_ref
+  local base_ref
   local lines=()
   while IFS= read -r line; do
-    if [ "${has_read_base_ref:-}" ]; then
+    if [ "${base_ref:-}" ]; then
       lines+=("$line")
       detect_companion_branch_override "$line"
     else
       base_ref="$line"
-      has_read_base_ref=true
     fi
   done < <(curl \
       -sSL \
@@ -395,7 +394,7 @@ patch_and_check_dependent() {
 
   pushd "$dependent_repo_dir" >/dev/null
 
-  if [ "${has_overridden_dependent_repo_ref:-}" ]; then
+  if [ "${has_overridden_dependent_ref:-}" ]; then
     echo "Skipping extra_dependencies ($extra_dependencies) as the dependent repository's ref has been overridden"
   else
     # It is necessary to patch in extra dependencies which have already been
@@ -499,7 +498,7 @@ main() {
     elif [ "${companion_branch_override[$dependent_repo]:-}" ]; then
       echo "Cloning dependent $dependent_repo with branch ${companion_branch_override[$dependent_repo]} from manual override"
       dependent_clone_options+=("--branch" "${companion_branch_override[$dependent_repo]}")
-      has_overridden_dependent_repo_ref=true
+      has_overridden_dependent_ref=true
     else
       for override in "${companion_overrides[@]}"; do
         echo "Processing companion override $override"
@@ -610,7 +609,7 @@ main() {
         dependent_clone_options+=("$branch_name")
 
         echo "Setting up the clone of $dependent_repo with options: ${dependent_clone_options[*]}"
-        has_overridden_dependent_repo_ref=true
+        has_overridden_dependent_ref=true
 
         break
       done
@@ -624,7 +623,7 @@ main() {
       "$dependent_repo_dir"
   fi
 
-  if [ "${has_overridden_dependent_repo_ref:-}" ]; then
+  if [ "${has_overridden_dependent_ref:-}" ]; then
     echo "Skipping master merge of $this_repo as the dependent repository's ref has been overridden"
   else
     # Merge master into this branch so that we have a better expectation of the

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -24,6 +24,7 @@ set -eu -o pipefail
 shopt -s inherit_errexit
 
 . "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/github_graphql.sh"
 
 get_arg required --org "$@"
 org="$out"
@@ -37,12 +38,16 @@ github_api_token="$out"
 get_arg optional --extra-dependencies "$@"
 extra_dependencies="${out:-}"
 
+get_arg optional-many --companion-overrides "$@"
+companion_overrides=("${out[@]}")
+
 set -x
 this_repo_dir="$PWD"
 this_repo="$(basename "$this_repo_dir")"
 companions_dir="$this_repo_dir/companions"
 extra_dependencies_dir="$this_repo_dir/extra_dependencies"
 github_api="https://api.github.com"
+github_graphql_api="https://api.github.com/graphql"
 org_github_prefix="https://github.com/$org"
 org_crates_prefix="git+$org_github_prefix"
 set +x
@@ -333,30 +338,37 @@ Both cases can be solved by merging master into $repo#$pr_number.
   fi
 }
 
+declare -A pr_base_ref
+pr_base_ref=()
 process_pr_description() {
   local repo="$1"
   local pr_number="$2"
 
-  if ! [[ "$pr_number" =~ ^[[:digit:]]+$ ]]; then
-    return
-  fi
-
   echo "Processing PR $repo#$pr_number"
 
+  local has_read_base_ref base_ref
   local lines=()
   while IFS= read -r line; do
-    lines+=("$line")
+    if [ "${has_read_base_ref:-}" ]; then
+      lines+=("$line")
+    else
+      base_ref="$line"
+      has_read_base_ref=true
+    fi
   done < <(curl \
       -sSL \
       -H "Authorization: token $github_api_token" \
       "$github_api/repos/$org/$repo/pulls/$pr_number" | \
-    jq -e -r ".body"
+    jq -e -r ".base.ref, .body"
   )
   # in case the PR has no body, jq should have printed "null" which effectively
   # means lines will always be populated with something
+  # shellcheck disable=SC2128
   if ! [ "$lines" ]; then
     die "No lines were read for the description of PR $pr_number (some error probably occurred)"
   fi
+
+  pr_base_ref["$repo"]="$base_ref"
 
   for line in "${lines[@]}"; do
     if [[ "$line" =~ [cC]ompanion:[[:space:]]*([^[:space:]]+) ]]; then
@@ -372,35 +384,39 @@ patch_and_check_dependent() {
 
   pushd "$dependent_repo_dir" >/dev/null
 
-  # It is necessary to patch in extra dependencies which have already been
-  # merged in previous steps of the Companion Build System's dependency chain.
-  # For instance, consider the following dependency chain:
-  #     Substrate -> Polkadot -> Cumulus
-  # When this script is running for Cumulus as the dependent, on Polkadot's
-  # pipeline, it is necessary to patch the master of Substrate into this
-  # script's branches because Substrate's master will contain the pull request
-  # which was part of the dependency chain for this PR and was merged before
-  # this script gets to run for the last time (after lockfile updates and before
-  # merge).
-  for extra_dependency in $extra_dependencies; do
-    echo "Cloning extra dependency $extra_dependency to patch its default branch into $this_repo and $dependent"
-    git clone \
-      --depth=1 \
-      "$org_github_prefix/$extra_dependency.git" \
-      "$extra_dependencies_dir/$extra_dependency"
+  if [ "${has_overridden_dependent_repo_ref:-}" ]; then
+    echo "Skipping extra_dependencies ($extra_dependencies) as the dependent repository's ref has been overridden"
+  else
+    # It is necessary to patch in extra dependencies which have already been
+    # merged in previous steps of the Companion Build System's dependency chain.
+    # For instance, consider the following dependency chain:
+    #     Substrate -> Polkadot -> Cumulus
+    # When this script is running for Cumulus as the dependent, on Polkadot's
+    # pipeline, it is necessary to patch the master of Substrate into this
+    # script's branches because Substrate's master will contain the pull request
+    # which was part of the dependency chain for this PR and was merged before
+    # this script gets to run for the last time (after lockfile updates and before
+    # merge).
+    for extra_dependency in $extra_dependencies; do
+      echo "Cloning extra dependency $extra_dependency to patch its default branch into $this_repo and $dependent"
+      git clone \
+        --depth=1 \
+        "$org_github_prefix/$extra_dependency.git" \
+        "$extra_dependencies_dir/$extra_dependency"
 
-    echo "Patching extra dependency $extra_dependency into $this_repo_dir"
-    diener patch \
-      --target "$org_github_prefix/$extra_dependency" \
-      --crates-to-patch "$extra_dependencies_dir/$extra_dependency" \
-      --path "$this_repo_dir/Cargo.toml"
+      echo "Patching extra dependency $extra_dependency into $this_repo_dir"
+      diener patch \
+        --target "$org_github_prefix/$extra_dependency" \
+        --crates-to-patch "$extra_dependencies_dir/$extra_dependency" \
+        --path "$this_repo_dir/Cargo.toml"
 
-    echo "Patching extra dependency $extra_dependency into $dependent"
-    diener patch \
-      --target "$org_github_prefix/$extra_dependency" \
-      --crates-to-patch "$extra_dependencies_dir/$extra_dependency" \
-      --path Cargo.toml
-  done
+      echo "Patching extra dependency $extra_dependency into $dependent"
+      diener patch \
+        --target "$org_github_prefix/$extra_dependency" \
+        --crates-to-patch "$extra_dependencies_dir/$extra_dependency" \
+        --path Cargo.toml
+    done
+  fi
 
   # Patch this repository (the dependency) into the dependent for the sake of
   # being able to test how the dependency graph will behave after the merge
@@ -444,37 +460,158 @@ patch_and_check_dependent() {
 }
 
 main() {
+  if ! [[ "$CI_COMMIT_REF_NAME" =~ ^[[:digit:]]+$ ]]; then
+    die "\"$CI_COMMIT_REF_NAME\" was not recognized as a pull request ref"
+  fi
+
   # Set the user name and email to make merging work
   git config --global user.name 'CI system'
   git config --global user.email '<>'
   git config --global pull.rebase false
-
-  # Merge master into this branch so that we have a better expectation of the
-  # integration still working after this PR lands.
-  # Since master's HEAD is being merged here, at the start the dependency chain,
-  # the same has to be done for all the companions because they might have
-  # accompanying changes for the code being brought in.
-  git fetch --force origin master
-  git show-ref origin/master
-  echo "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
-  git merge origin/master \
-    --verbose \
-    --no-edit \
-    -m "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
-
-  discover_our_crates
 
   # process_pr_description calls itself for each companion in the description on
   # each detected companion PR, effectively considering all companion references
   # on all PRs
   process_pr_description "$this_repo" "$CI_COMMIT_REF_NAME"
 
+  # This PR might be targetting a custom ref (i.e. not master) through
+  # --companion-overrides, in which case it won't be proper to merge master
+  # (since it's not targetting master) before realizing the companion checks
   local dependent_repo_dir="$companions_dir/$dependent_repo"
   if ! [ -e "$dependent_repo_dir" ]; then
-    echo "Cloning $dependent_repo directly as it was not detected as a companion"
+    local dependent_clone_options=(
+      --depth=1
+    )
+
+    if [ "${pr_base_ref[$this_repo]}" == "master" ]; then
+      echo "Cloning dependent $dependent_repo directly as it was not detected as a companion"
+    else
+      for override in "${companion_overrides[@]}"; do
+        local this_repo_override this_repo_override_prefix dependent_repo_override dependent_repo_override_prefix
+
+        while IFS= read -r line; do
+          if [[ "$line" =~ ^[[:space:]]*$this_repo:[[:space:]]*(.*) ]]; then
+            this_repo_override="${BASH_REMATCH[1]}"
+            if [[ "$this_repo_override" =~ ^(.*)\* ]]; then
+              this_repo_override_prefix="${BASH_REMATCH[1]}"
+            fi
+          elif [[ "$line" =~ ^[[:space:]]*$dependent_repo:[[:space:]]*(.*) ]]; then
+            dependent_repo_override="${BASH_REMATCH[1]}"
+            if [[ "$dependent_repo_override" =~ ^(.*)\* ]]; then
+              dependent_repo_override_prefix="${BASH_REMATCH[1]}"
+            fi
+          fi
+        done < <(echo "$override")
+
+        if [[
+          ! ("${this_repo_override:-}") ||
+          ! ("${dependent_repo_override:-}")
+        ]]; then
+          continue
+        fi
+
+        local base_ref_prefix="${this_repo_override_prefix:-$this_repo_override}"
+        if [ "${pr_base_ref[$this_repo]:0:${#base_ref_prefix}}" != "$base_ref_prefix" ]; then
+          continue
+        fi
+
+        local this_repo_override_suffix
+        if [ "${this_repo_override_prefix:-}" ]; then
+          this_repo_override_suffix="${pr_base_ref[$this_repo]:${#this_repo_override_prefix}}"
+        fi
+
+        dependent_clone_options+=("--branch")
+        local branch_name
+        if [[
+          ("${dependent_repo_override_prefix:-}") &&
+          ("${this_repo_override_suffix:-}")
+        ]]; then
+          branch_name="${dependent_repo_override_prefix}${this_repo_override_suffix}"
+
+          echo "Checking if $branch_name exists in $dependent_repo"
+          local response_code
+          response_code="$(curl \
+            -o /dev/null \
+            -sSL \
+            -H "Authorization: token $github_api_token" \
+            -w '%{response_code}' \
+            "$github_api/repos/$org/$dependent_repo/branches/$branch_name"
+          )"
+
+          if [ "$response_code" -eq 200 ]; then
+            echo "Branch $branch_name exists in $dependent_repo. Proceeding..."
+          else
+            echo "Branch $branch_name doesn't exist in $dependent_repo (status code $response_code)"
+            echo "Fetching the list of branches in $dependent_repo to find a suitable replacement..."
+
+            local successor_branch_name
+            while IFS= read -r line; do
+              echo "Got candidate branch $line in $dependent_repo's refs"
+              if [ "${line:0:${#dependent_repo_override_prefix}}" == "$dependent_repo_override_prefix" ]; then
+                echo "Found candidate branch $line as the successor of $branch_name"
+                successor_branch_name="$line"
+                break
+              fi
+            done < <(ghgql_post \
+              "$github_graphql_api" \
+              "$github_api_token" \
+              "$(
+                ghgql_latest_repositories_refs_query \
+                  "$org" \
+                  "$dependent_repo" \
+                  "$dependent_repo_override_prefix"
+              )" | jq -r '.data.repository.refs.edges[].node.name'
+            )
+
+            if [ "${successor_branch_name:-}" ]; then
+              echo "Choosing branch $line as a successor for $branch_name"
+              branch_name="$successor_branch_name"
+              unset successor_branch_name
+            else
+              die "Unable to find the successor for non-existent branch $branch_name of $dependent_repo"
+            fi
+          fi
+        else
+          branch_name="$dependent_repo_override"
+        fi
+        dependent_clone_options+=("$branch_name")
+
+        echo "Setting up the clone of $dependent_repo with options: ${dependent_clone_options[*]}"
+
+        # when a ref is matched through --companion-overrides, don't merge
+        # master into the branch in order to avoid disturbing its state
+        has_overridden_dependent_repo_ref=true
+
+        break
+      done
+    fi
+
     dependent_repo_dir="$this_repo_dir/$dependent_repo"
-    git clone --depth=1 "$org_github_prefix/$dependent_repo.git" "$dependent_repo_dir"
+    # shellcheck disable=SC2068
+    git clone \
+      ${dependent_clone_options[@]} \
+      "$org_github_prefix/$dependent_repo.git" \
+      "$dependent_repo_dir"
   fi
+
+  if [ "${has_overridden_dependent_repo_ref:-}" ]; then
+    echo "Skipping master merge of $this_repo as the dependent repository's ref has been overridden"
+  else
+    # Merge master into this branch so that we have a better expectation of the
+    # integration still working after this PR lands.
+    # Since master's HEAD is being merged here, at the start the dependency chain,
+    # the same has to be done for all the companions because they might have
+    # accompanying changes for the code being brought in.
+    git fetch --force origin master
+    git show-ref origin/master
+    echo "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
+    git merge origin/master \
+      --verbose \
+      --no-edit \
+      -m "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
+  fi
+
+  discover_our_crates
 
   patch_and_check_dependent "$dependent_repo" "$dependent_repo_dir"
 }

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -502,8 +502,9 @@ main() {
       has_overridden_dependent_repo_ref=true
     else
       for override in "${companion_overrides[@]}"; do
-        local this_repo_override this_repo_override_prefix dependent_repo_override dependent_repo_override_prefix
+        echo "Processing companion override $override"
 
+        local this_repo_override this_repo_override_prefix dependent_repo_override dependent_repo_override_prefix
         while IFS= read -r line; do
           if [[ "$line" =~ ^[[:space:]]*$this_repo:[[:space:]]*(.*) ]]; then
             this_repo_override="${BASH_REMATCH[1]}"

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -342,6 +342,7 @@ declare -A companion_branch_override
 companion_branch_override=()
 detect_companion_branch_override() {
   local line="$1"
+  # detects the form "repository companion branch: foo"
   if [[ "$line" =~ ^[[:space:]]*([^[:space:]]+)[[:space:]]+companion[[:space:]]+branch:[[:space:]]*([^[:space:]]+) ]]; then
     companion_branch_override["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
   fi

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -569,14 +569,12 @@ main() {
             echo "Branch $branch_name doesn't exist in $dependent_repo (status code $response_code)"
             echo "Fetching the list of branches in $dependent_repo to find a suitable replacement..."
 
-            # The guessing for the inexistent ref branch works by taking the
-            # most recently updated branch (ordered by commit date) which
-            # follows the pattern we're following for the branch name. For
-            # example, if polkadot-v0.9.20 does not exist, take the latest (by
-            # commit date) branch following a "polkadot-v*" pattern, which
-            # happens to be polkadot-v0.9.19 as of this writing; in this
-            # scenario, polkadot-v0.9.19 should be chosen as a best-effort guess
-            # replacement for polkadot-v0.9.20 because it's the most recent.
+            # The guessing for a replacement branch works by taking the most
+            # recently updated branch (ordered by commit date) which follows the
+            # pattern we've matched for the branch name. For example, if
+            # polkadot-v0.9.20 does not exist, instead use the latest (by commit
+            # date) branch following a "polkadot-v*" pattern, which happens to
+            # be polkadot-v0.9.19 as of this writing.
             local replacement_branch_name
             while IFS= read -r line; do
               echo "Got candidate branch $line in $dependent_repo's refs"

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -342,7 +342,7 @@ declare -A companion_branch_override
 companion_branch_override=()
 detect_companion_branch_override() {
   local line="$1"
-  # detects the form "repository companion branch: foo"
+  # detects the form "[repository] companion branch: [branch]"
   if [[ "$line" =~ ^[[:space:]]*([^[:space:]]+)[[:space:]]+companion[[:space:]]+branch:[[:space:]]*([^[:space:]]+) ]]; then
     companion_branch_override["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
   fi
@@ -484,9 +484,10 @@ main() {
   # on all PRs
   process_pr_description "$this_repo" "$CI_COMMIT_REF_NAME"
 
-  # This PR might be targetting a custom ref (i.e. not master) through
-  # --companion-overrides, in which case it won't be proper to merge master
-  # (since it's not targetting master) before realizing the companion checks
+  # This PR might be targetting a custom ref (i.e. not master) through companion
+  # overrides from --companion-overrides or the PR's description, in which case
+  # it won't be proper to merge master (since it's not targetting master) before
+  # performing the companion checks
   local dependent_repo_dir="$companions_dir/$dependent_repo"
   if ! [ -e "$dependent_repo_dir" ]; then
     local dependent_clone_options=(

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -587,7 +587,7 @@ main() {
               "$github_graphql_api" \
               "$github_api_token" \
               "$(
-                ghgql_latest_repositories_refs_query \
+                ghgql_most_recent_branches_query \
                   "$org" \
                   "$dependent_repo" \
                   "$dependent_repo_override_prefix"

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -348,8 +348,8 @@ detect_companion_branch_override() {
   fi
 }
 
-declare -A pr_base_ref
-pr_base_ref=()
+declare -A pr_target_branch
+pr_target_branch=()
 process_pr_description() {
   local repo="$1"
   local pr_number="$2"
@@ -379,7 +379,7 @@ process_pr_description() {
     die "No lines were read for the description of PR $pr_number (some error probably occurred)"
   fi
 
-  pr_base_ref["$repo"]="$base_ref"
+  pr_target_branch["$repo"]="$base_ref"
 
   for line in "${lines[@]}"; do
     if [[ "$line" =~ [cC]ompanion:[[:space:]]*([^[:space:]]+) ]]; then
@@ -494,7 +494,7 @@ main() {
       --depth=1
     )
 
-    if [ "${pr_base_ref[$this_repo]}" == "master" ]; then
+    if [ "${pr_target_branch[$this_repo]}" == "master" ]; then
       echo "Cloning dependent $dependent_repo directly as it was not detected as a companion"
     elif [ "${companion_branch_override[$dependent_repo]:-}" ]; then
       echo "Cloning dependent $dependent_repo with branch ${companion_branch_override[$dependent_repo]} from manual override"
@@ -529,13 +529,13 @@ main() {
         echo "Detected override $this_repo_override for $this_repo and override $dependent_repo_override for $dependent_repo"
 
         local base_ref_prefix="${this_repo_override_prefix:-$this_repo_override}"
-        if [ "${pr_base_ref[$this_repo]:0:${#base_ref_prefix}}" != "$base_ref_prefix" ]; then
+        if [ "${pr_target_branch[$this_repo]:0:${#base_ref_prefix}}" != "$base_ref_prefix" ]; then
           continue
         fi
 
         local this_repo_override_suffix
         if [ "${this_repo_override_prefix:-}" ]; then
-          this_repo_override_suffix="${pr_base_ref[$this_repo]:${#this_repo_override_prefix}}"
+          this_repo_override_suffix="${pr_target_branch[$this_repo]:${#this_repo_override_prefix}}"
         fi
 
         dependent_clone_options+=("--branch")

--- a/github_graphql.sh
+++ b/github_graphql.sh
@@ -1,0 +1,49 @@
+ghgql_latest_repositories_refs_query() {
+  unset out
+
+  local org="$1"
+  local repo="$2"
+  local refs_query="$3"
+
+  echo "
+    query { 
+      repository(owner: \"$org\", name: \"$repo\") {
+        refs(
+          refPrefix: \"refs/heads/\",
+          first: 32,
+          query: \"$refs_query\",
+          orderBy: { field: TAG_COMMIT_DATE, direction: DESC }
+        ) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+    }
+  "
+}
+
+ghgql_post() {
+  local github_graphql_api="$1"
+  local github_api_token="$2"
+  local query="$3"
+
+  local req_body
+  req_body="{ \"query\": \"$(echo "$query" | tr -d '\n' | sed 's/"/\\"/g')\" }"
+
+  >&2 echo "
+Sending GraphQL body to $github_graphql_api
+Raw query: $query
+JSON body: $req_body
+"
+
+  curl \
+    -sSL \
+    -H "Content-Type: application/json" \
+    -H "Authorization: bearer $github_api_token" \
+    -X POST \
+    -d "$req_body" \
+    "$github_graphql_api"
+}

--- a/github_graphql.sh
+++ b/github_graphql.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 ghgql_latest_repositories_refs_query() {
   unset out
 

--- a/github_graphql.sh
+++ b/github_graphql.sh
@@ -36,7 +36,7 @@ ghgql_post() {
   >&2 echo "
 Sending GraphQL body to $github_graphql_api
 Raw query: $query
-JSON body: $req_body
+Request body: $req_body
 "
 
   curl \

--- a/github_graphql.sh
+++ b/github_graphql.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ghgql_latest_repositories_refs_query() {
+ghgql_most_recent_branches_query() {
   local org="$1"
   local repo="$2"
   local refs_query="$3"

--- a/github_graphql.sh
+++ b/github_graphql.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 ghgql_latest_repositories_refs_query() {
-  unset out
-
   local org="$1"
   local repo="$2"
   local refs_query="$3"

--- a/utils.sh
+++ b/utils.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 die() {
   if [ "${1:-}" ]; then
     >&2 echo "$1"

--- a/utils.sh
+++ b/utils.sh
@@ -28,11 +28,13 @@ get_arg() {
   local option_arg="$1"
   shift
 
+  local args=("$@")
+
   unset out
   out=()
 
   local get_next_arg
-  for arg in "$@"; do
+  for arg in "${args[@]}"; do
     if [ "${get_next_arg:-}" ]; then
       out+=("$arg")
       unset get_next_arg


### PR DESCRIPTION
*Note*: This will require a PR on Substrate after it's merged

The intended usage pattern on CI is provided by [`--companion-overrides`](https://github.com/paritytech/substrate/pull/11282/files#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R158) from [`$COMPANION_OVERRIDES`](https://github.com/paritytech/substrate/pull/11282/files#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R164).

Use-case of correlating an existing matching branch: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1526107#L98
  - `release-v0.9.20` was used for the Polkadot companion because I am targetting `polkadot-v0.9.20` in the PR (notice the version correlation). This required [`$COMPANION_OVERRIDES`](https://github.com/paritytech/substrate/pull/11282/files#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R164).

Use-case of correlated an existing branch by guess: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1526106#L124
   - `polkadot-v0.9.19` was used for the Cumulus companion because the script tried to use `polkadot-v0.9.20` (correlated from `polkadot-v0.9.20` which I am targetting in the PR), which doesn't exist, thus it guessed the first. This required [`$COMPANION_OVERRIDES`](https://github.com/paritytech/substrate/pull/11282/files#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R164).

Use-case of overriding the companion branch: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1526105#L98
  - This required putting `cumulus companion branch: polkadot-v0.9.18` in the pull request's description

---

close #32 