### PR TITLE
Narrow companion reference regular expression

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -381,7 +381,7 @@ process_pr_description() {
   pr_target_branch["$repo"]="$base_ref"
 
   for line in "${lines[@]}"; do
-    if [[ "$line" =~ [cC]ompanion:[[:space:]]*([^[:space:]]+) ]]; then
+    if [[ "$line" =~ ^[[:space:]]*[^[:space:]]+[[:space:]]+[cC]ompanion:[[:space:]]*([^[:space:]]+) ]]; then
       echo "Detected companion in the PR description of $repo#$pr_number: ${BASH_REMATCH[1]}"
       process_pr_description_line "${BASH_REMATCH[1]}" "$repo#$pr_number"
     fi


### PR DESCRIPTION
Narrow the companion reference regular expression so that the pull request template's (showcased in https://github.com/paritytech/substrate/pull/11392) "Polkadot Companion" segment does not incorrectly get misunderstood as a companion reference line of the form `something companion: link`.

After this PR the line **has to start with** `something companion:` whereas before the `something companion:` form could appear anywhere in the line (which is what caused the bug mentioned in https://github.com/paritytech/substrate/pull/11392#pullrequestreview-968988846).

fix #39 