### PR TITLE
bench-bot: display hardware specs at the start of the command

### DIFF
--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -139,6 +139,7 @@ main() {
   git reset --hard "$GH_HEAD_SHA"
 
   set -x
+  2>/dev/null lshw -short -sanitize
   cargo --version
   rustc --version
   cargo +nightly --version


### PR DESCRIPTION
close #55 