### PR TITLE
Create bench-bot configuration for Cumulus

### DIFF
--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -109,6 +109,27 @@ bench_pallet() {
         ;;
       esac
     ;;
+    cumulus)
+      args=(
+        --features=runtime-benchmarks
+        "${bench_pallet_common_args[@]}"
+        "--pallet=$pallet"
+        "--chain=${chain}-dev"
+      )
+
+      case "$kind" in
+        pallet)
+          args+=(
+            --json
+            --header=./file_header.txt
+            "--output=./parachains/runtimes/assets/${chain}/src/weights"
+          )
+        ;;
+        *)
+          die "Kind $kind is not supported for $repository in bench_pallet"
+        ;;
+      esac
+    ;;
     *)
       die "Repository $repository is not supported in bench_pallet"
     ;;

--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -120,7 +120,7 @@ bench_pallet() {
       case "$kind" in
         pallet)
           args+=(
-            --json
+            --json-file="${ARTIFACTS_DIR}/bench.json"
             --header=./file_header.txt
             "--output=./parachains/runtimes/assets/${chain}/src/weights"
           )

--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -113,8 +113,8 @@ bench_pallet() {
       args=(
         --features=runtime-benchmarks
         "${bench_pallet_common_args[@]}"
-        "--pallet=$pallet"
-        "--chain=${chain}-dev"
+        --pallet="$pallet"
+        --chain="${chain}-dev"
       )
 
       case "$kind" in
@@ -122,7 +122,7 @@ bench_pallet() {
           args+=(
             --json-file="${ARTIFACTS_DIR}/bench.json"
             --header=./file_header.txt
-            "--output=./parachains/runtimes/assets/${chain}/src/weights"
+            --output="./parachains/runtimes/assets/${chain}/src/weights"
           )
         ;;
         *)


### PR DESCRIPTION
This will enable the `/cmd queue -c bench-bot $ pallet [runtime] [pallet]` command for Cumulus. The benchmarking command is based on https://github.com/paritytech/cumulus/blob/eff2c9e498ba51766921eed2055aa3a01848dfbd/.gitlab-ci.yml#L287.

Example: `/cmd queue -c bench-bot $ pallet statemine pallet_balances` would generate the weights for https://github.com/paritytech/cumulus/tree/eff2c9e498ba51766921eed2055aa3a01848dfbd/parachains/runtimes/assets/statemine/src/weights/pallet_balances.rs.

close #50 