### PR TITLE
Introduce try-runtime-bot script

### DIFF
--- a/cmd_runner.sh
+++ b/cmd_runner.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
+set -eu -o pipefail
+shopt -s inherit_errexit
+
+cmd_runner_display_rust_toolchain() {
+  cargo --version
+  rustc --version
+  cargo +nightly --version
+  rustc +nightly --version
+}
+
+cmd_runner_setup() {
+  # set the Git user, otherwise Git commands will fail
+  git config --global user.name command-bot
+  git config --global user.email "<>"
+
+  # Reset the branch to how it was on GitHub when the bot command was issued
+  git reset --hard "$GH_HEAD_SHA"
+
+  cmd_runner_display_rust_toolchain
+
+  # https://github.com/paritytech/substrate/pull/10700
+  # https://github.com/paritytech/substrate/blob/b511370572ac5689044779584a354a3d4ede1840/utils/wasm-builder/src/wasm_project.rs#L206
+  export WASM_BUILD_WORKSPACE_HINT="$PWD"
+}
+
+cmd_runner_apply_patches() {
+  get_arg optional --setup-dirs-cleanup "$@"
+  local setup_cleanup="${out:-}"
+
+  while IFS= read -r line; do
+    if ! [[ "$line" =~ ^PATCH_([^=]+)=(.*)$ ]]; then
+      continue
+    fi
+    echo "Matched environment variable for patching: $line"
+
+    local repository="${BASH_REMATCH[1]}"
+    local branch="${BASH_REMATCH[2]}"
+    local repository_dir=".git/cmd-runner-patch/$repository"
+
+    mkdir -p .git/cmd-runner-patch
+    rm -rf "$repository_dir"
+    git clone \
+      --depth 1 \
+      "https://token:${GITHUB_TOKEN}@github.com/${GH_OWNER}/${repository}.git" \
+      "$repository_dir"
+    tmp_dirs+=("$repository_dir")
+    echo "Cloned repository for patching: ${GH_OWNER}/${repository}"
+
+    >/dev/null pushd "$repository_dir"
+
+    local head_sha
+    head_sha="$(git rev-parse HEAD)"
+
+    git checkout --quiet "$head_sha"
+    2>/dev/null git branch -D to-patch || :
+
+    local ref
+    if [[ "$branch" =~ ^[[:digit:]]+$ ]]; then
+      ref="pull/$branch/head"
+    else
+      ref="$branch"
+    fi
+
+    git remote add \
+      github \
+      "https://token:${GITHUB_TOKEN}@github.com/${GH_OWNER}/${repository}.git"
+    git fetch github "$ref:to-patch"
+    git checkout to-patch
+    git remote remove github
+
+    echo "Checked out $ref of repository $repository at commit sha $(git rev-parse HEAD) for patching"
+
+    >/dev/null popd
+
+    diener patch \
+      --target "https://github.com/${GH_OWNER}/${GH_OWNER_REPO}" \
+      --crates-to-patch "$repository_dir" \
+      --path Cargo.toml
+  done < <(env)
+
+  if [ "$setup_cleanup" ]; then
+    cleanup() {
+      exit_code=$?
+      rm -rf "${tmp_dirs[@]}"
+      exit $exit_code
+    }
+    trap cleanup EXIT
+  fi
+}

--- a/cmd_runner.sh
+++ b/cmd_runner.sh
@@ -31,6 +31,9 @@ cmd_runner_apply_patches() {
   get_arg optional --setup-dirs-cleanup "$@"
   local setup_cleanup="${out:-}"
 
+  local repositories_dir=".git/cmd-runner-patch"
+  tmp_dirs+=("$repositories_dir")
+
   while IFS= read -r line; do
     if ! [[ "$line" =~ ^PATCH_([^=]+)=(.*)$ ]]; then
       continue
@@ -39,9 +42,8 @@ cmd_runner_apply_patches() {
 
     local repository="${BASH_REMATCH[1]}"
     local branch="${BASH_REMATCH[2]}"
-    local repository_dir=".git/cmd-runner-patch/$repository"
+    local repository_dir="$repositories_dir/$repository"
 
-    mkdir -p .git/cmd-runner-patch
     rm -rf "$repository_dir"
     git clone \
       --depth 1 \

--- a/try-runtime-bot.sh
+++ b/try-runtime-bot.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+shopt -s inherit_errexit
+
+. "$(dirname "${BASH_SOURCE[0]}")/cmd_runner.sh"
+
+main() {
+  cmd_runner_setup
+
+  cmd_runner_apply_patches --setup-cleanup true
+
+  local preset_args=(
+    run
+    # Requirement: always run the command in release mode.
+    # See https://github.com/paritytech/command-bot/issues/26#issue-1049555966
+    --release
+    # "--quiet" should be kept so that the output doesn't get polluted
+    # with a bunch of compilation stuff
+    --quiet
+    --features=try-runtime
+    try-runtime
+  )
+
+  set -x
+  export RUST_LOG="${RUST_LOG:-remote-ext=debug,runtime=trace}"
+  cargo "${preset_args[@]}" -- "$@"
+}
+
+main "$@"

--- a/utils.sh
+++ b/utils.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [ "${LOADED_UTILS_SH:-}" ]; then
+  return
+else
+  export LOADED_UTILS_SH=true
+fi
+
 die() {
   if [ "${1:-}" ]; then
     >&2 echo "$1"
@@ -69,10 +75,4 @@ get_arg() {
   else
     unset out
   fi
-}
-
-try() {
-  set +e
-  $@
-  set -e
 }


### PR DESCRIPTION
Both try-runtime-bot and bench-bot have a feature request for patching some dependency into the branch before executing the command: https://github.com/paritytech/command-bot/issues/83, #41. Moreover, the bots both execute some command for the core project's CLIs, so their pre-command preparation end up also being very similar. That being the case it makes sense to create a set of functions for providing shared functionality for both (tip: it's in cmd_runner.sh).

The `try-runtime` configuration is hardcoded directly into command-bot at the moment (https://github.com/paritytech/command-bot/blob/6245603b60e264f9663e9e2a5059225ae8709aa7/src/core.ts#L39), which means we have to redeploy the bot when the command needs to be tweaked; that is not as flexible as bench-bot since the latter can be tweaked promptly by submitting a PR to this repository. We can alleviate this problem by also creating a script for the try-runtime-bot.

In summary

- Export shared functionality for bench-bot + try-runtime-bot to a library (cmd_runner.sh)
- Introduce try-runtime-bot script

related to https://github.com/paritytech/command-bot/issues/90
related to https://github.com/paritytech/command-bot/issues/83
close #41