### PR TITLE
Support XCM benchmarks for Cumulus

### DIFF
--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -31,11 +31,12 @@ bench_pallet_common_args=(
 bench_pallet() {
   local kind="$1"
   local runtime="$2"
-  local pallet="$3"
 
   local args
   case "$repository" in
     substrate)
+      local pallet="$3"
+
       local pallet_prefix="pallet_"
 
       local pallet_id
@@ -72,6 +73,8 @@ bench_pallet() {
       esac
     ;;
     polkadot)
+      local pallet="$3"
+
       args=(
         --features=runtime-benchmarks
         "${bench_pallet_common_args[@]}"
@@ -111,6 +114,9 @@ bench_pallet() {
       esac
     ;;
     cumulus)
+      local chain_type="$3"
+      local pallet="$4"
+
       args=(
         --bin=parachain-template-node
         --features=runtime-benchmarks
@@ -124,7 +130,15 @@ bench_pallet() {
           args+=(
             --json-file="${ARTIFACTS_DIR}/bench.json"
             --header=./file_header.txt
-            --output="./parachains/runtimes/assets/${runtime}/src/weights"
+            --output="./parachains/runtimes/$chain_type/$runtime/src/weights"
+          )
+        ;;
+        xcm)
+          args+=(
+            --template=./xcm/pallet-xcm-benchmarks/template.hbs
+            --json-file="${ARTIFACTS_DIR}/bench.json"
+            --header=./file_header.txt
+            --output="./parachains/runtimes/$chain_type/$runtime/src/weights/xcm"
           )
         ;;
         *)

--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -134,8 +134,9 @@ bench_pallet() {
           )
         ;;
         xcm)
+          mkdir -p "./parachains/runtimes/$chain_type/$runtime/src/weights/xcm"
           args+=(
-            --template=./xcm/pallet-xcm-benchmarks/template.hbs
+            --template=./templates/xcm-bench-template.hbs
             --json-file="${ARTIFACTS_DIR}/bench.json"
             --header=./file_header.txt
             --output="./parachains/runtimes/$chain_type/$runtime/src/weights/xcm"


### PR DESCRIPTION
This PR adds the XCM configuration for Cumulus and an extra parameter `$chain_type`. After this PR the Cumulus syntax will change:

**Old**

`/cmd queue -c bench-bot $ pallet runtime pallet_name`

**New**

`/cmd queue -c bench-bot $ [pallet | xcm] runtime chain_type pallet_name`

Where `chain_type` can be one of the folders inside of `parachains/runtimes`, i.e. at the moment `assets`, `testing`, `starters` and `contracts`.

We should update the examples in https://github.com/paritytech/pipeline-scripts/issues/63 and also post a comment to announce the change.

---

Related to https://github.com/paritytech/cumulus/pull/1454

close #66