### PR TITLE
Full CI integration for dependents' projects

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -1,23 +1,33 @@
 #!/usr/bin/env bash
-#
-# Ensure that a PR does not introduce downstream breakages on this project's dependents by
-# performing checks using this branch's code. If dependents are specified as companions, they are
-# patched to use the code we have in this branch; otherwise, we run the the checks against their
-# default branch.
 
-# Companion dependents are extracted from the PR's description when lines conform to the following
+# This script validates that a given PR does not introduce breakages to its
+# dependents. The validation revolves around patching the dependencies into the
+# dependent targetted by this check ahead of time, as if to simulate how it's
+# going to behave after all PRs are merged.
+# ---
+# First it tries to extract the PRs to be used for this check, a.k.a the
+# COMPANIONS, from the PR's description when lines conform to the following
 # formats:
 # [cC]ompanion: https://github.com/org/repo/pull/pr_number
 # [cC]ompanion: org/repo#pr_number
 # [cC]ompanion: repo#pr_number
+# If no companions are found for the targetted dependents, instead their default
+# branch is used.
+# ---
+# After all dependencies are collected they'll be patched into the dependent,
+# which will result in a single branch for which a pipeline will be created on
+# GitLab. Should the created pipeline succeed we'll attempt to save the check's
+# data to Redis so that it can be leveraged for *potentially* skipping a
+# redundant run of the dependent's pipeline in the future
+# (./check_dependent_project_pipeline.sh).
 
 echo "
 
 check_dependent_project
 ========================
 
-This check ensures that this project's dependents do not suffer downstream breakages from new code
-changes.
+This check validates that this project's dependents are not suffering breakages
+from this project's pull requests.
 "
 
 set -eu -o pipefail
@@ -26,11 +36,53 @@ shopt -s inherit_errexit
 . "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 . "$(dirname "${BASH_SOURCE[0]}")/github_graphql.sh"
 
+if [[
+  # patched companions sent to GitLab
+  "${CI_COMMIT_REF_NAME:-}" =~ ^cbs-.*-CMP([[:digit:]]+)$
+]]; then
+  this_pr_number=${BASH_REMATCH[1]}
+elif [[
+  # PRs mirrored to GitLab
+  "${CI_COMMIT_REF_NAME:-}" =~ ^[[:digit:]]+$
+]]; then
+  this_pr_number=$CI_COMMIT_REF_NAME
+else
+  echo "\$CI_COMMIT_REF_NAME was not recognized as a pull request ref: ${CI_COMMIT_REF_NAME:-}"
+  exit 0
+fi
+
+# generate a unique name for the patched branch with regards to this project and
+# the dependent. $CI_PROJECT_ID needs to be added so it doesn't collide with a
+# dependency check from another repository (e.g. both Substrate and Polkadot
+# have check-dependent-cumulus).
+gitlab_dependent_branch_name="cbs-$CI_PROJECT_ID-PR$this_pr_number"
+
 get_arg required --org "$@"
 org="$out"
 
 get_arg required --dependent-repo "$@"
-dependent_repo="$out"
+dependent="$out"
+
+get_arg required --gitlab-url "$@"
+gitlab_url="$out"
+if [[ "$gitlab_url" =~ ^([a-zA-Z]+://)(.*) ]]; then
+  gitlab_url_prefix="${BASH_REMATCH[1]}"
+  gitlab_domain="${BASH_REMATCH[2]}"
+else
+  gitlab_url_prefix="https://"
+  gitlab_domain="$gitlab_url"
+fi
+
+get_arg required --gitlab-dependent-path "$@"
+gitlab_dependent_path="$out"
+
+# gitlab_dependent_token needs `api` and `write_repository` scopes
+# - `write_repository` so that we'll be able to push the patched dependent
+#   branch to GitLab
+# - `api` so that we'll be able to create a pipeline for the patched dependent
+#   branch
+get_arg required --gitlab-dependent-token "$@"
+gitlab_dependent_token="$out"
 
 get_arg required --github-api-token "$@"
 github_api_token="$out"
@@ -44,16 +96,26 @@ companion_overrides=("${out[@]}")
 set -x
 this_repo_dir="$PWD"
 this_repo="$(basename "$this_repo_dir")"
-companions_dir="$this_repo_dir/companions"
-extra_dependencies_dir="$this_repo_dir/extra_dependencies"
+companions_dir="$this_repo_dir/.git/companions"
+extra_dependencies_dir="$this_repo_dir/.git/extra_dependencies"
 github_api="https://api.github.com"
 github_graphql_api="https://api.github.com/graphql"
 org_github_prefix="https://github.com/$org"
 org_crates_prefix="git+$org_github_prefix"
 set +x
 
+dependent_git_history_depth=100
+
+cleanup() {
+  rm -rf "$companions_dir" "$extra_dependencies_dir"
+}
+cleanup
+trap cleanup EXIT
+
 our_crates=()
 discover_our_crates() {
+  local dir="$1"
+
   # workaround for early exits not being detected in command substitution
   # https://unix.stackexchange.com/questions/541969/nested-command-substitution-does-not-stop-a-script-on-a-failure-even-if-e-and-s
   local last_line
@@ -75,7 +137,10 @@ discover_our_crates() {
     fi
   # dependencies with {"source": null} are the ones in this project's workspace,
   # hence the getpath($p)==null in the jq script below
-  done < <(cargo metadata --quiet --format-version=1 | jq -r '
+  done < <(cargo metadata \
+    --quiet \
+    --format-version=1 \
+    --manifest-path "$dir/Cargo.toml" | jq -r '
     . as $in |
     paths |
     select(.[-1]=="source" and . as $p | $in | getpath($p)==null) as $path |
@@ -117,7 +182,7 @@ match_dependent_crates() {
           # git+https://github.com/$org/$repo
           "$line" == "$our_crates_source" ||
           # git+https://github.com/$org/$repo?branch=master
-          "${line:0:$(( ${#our_crates_source} + 1 ))}" == "${our_crates_source}?"
+          "${line::$(( ${#our_crates_source} + 1 ))}" == "${our_crates_source}?"
         ]]; then
           local found
           for our_crate in "${our_crates[@]}"; do
@@ -199,17 +264,14 @@ process_pr_description_line() {
       fi
     done
 
-    local state closed mergeable ref sha
-    read -d '\n' -r state closed mergeable ref sha < <(curl \
+    local state closed
+    read -d '\n' -r state closed < <(curl \
         -sSL \
         -H "Authorization: token $github_api_token" \
         "$github_api/repos/$org/$repo/pulls/$pr_number" | \
       jq -e -r "[
         .state,
-        .closed,
-        .mergeable,
-        .head.ref,
-        .head.sha
+        .closed
       ] | .[]"
     # https://stackoverflow.com/questions/40547032/bash-read-returns-with-exit-code-1-even-though-it-runs-as-expected
     # ignore the faulty exit code since read still is regardless still reading the values we want
@@ -220,52 +282,33 @@ process_pr_description_line() {
       return
     fi
 
-    if [ "$mergeable" != "true" ]; then
-      die "Github API says $repo#$pr_number is not mergeable"
-    fi
-
     companions+=("$repo")
 
-    # Heuristic: assume the companion PR has a common merge ancestor with master
-    # in its last N commits.
-    local merge_ancestor_max_depth=100
-
-    # Clone the default branch of this companion's target repository (assumed to
-    # be named "master")
     git clone \
-      --depth=$merge_ancestor_max_depth \
+      --depth=$dependent_git_history_depth \
       "$org_github_prefix/$repo.git" \
       "$companions_dir/$repo"
+
     pushd "$companions_dir/$repo" >/dev/null
 
-    # Show what branches we got after cloning the repository
-    git show-ref
+    local branch_name="PR-$pr_number"
+    git fetch --depth=$dependent_git_history_depth origin "pull/$pr_number/head:$branch_name"
+    git checkout "$branch_name"
 
-    # Clone the companion's branch
-    echo "Cloning the companion $repo#$pr_number (branch $ref, SHA $sha)"
-    git fetch --depth=$merge_ancestor_max_depth origin "pull/$pr_number/head:$ref"
-    git checkout "$ref"
+    local head_sha
+    head_sha="$(git rev-parse HEAD)"
+    branch_name="$head_sha"
+    git branch -m "$branch_name"
 
-echo "
-Attempting to merge $repo#$pr_number with master after fetching its last $merge_ancestor_max_depth commits.
+    echo "Cloned companion $repo#$pr_number at commit $head_sha"
 
-If this step fails, either:
+    >/dev/null popd
 
-- $repo#$pr_number has conflicts with master
+    merge_upstream "$repo" "$companions_dir/$repo"
 
-OR
-
-- A common merge ancestor could not be found between master and the last $merge_ancestor_max_depth commits of $repo#$pr_number.
-
-Both cases can be solved by merging master into $repo#$pr_number.
-"
-    git show-ref origin/master
-    git merge origin/master \
-      --verbose \
-      --no-edit \
-      -m "Merge master of $repo into companion $repo#$pr_number"
-
-    popd >/dev/null
+    if [ "$repo" == "$dependent" ]; then
+      dependent_pr="$pr_number"
+    fi
 
     # collect also the companions of companions
     process_pr_description "$repo" "$pr_number"
@@ -324,42 +367,433 @@ process_pr_description() {
   done
 }
 
+update_local_crates() {
+  local gitlab_destination="$1"
+
+  local last_line
+  local crates=()
+  while IFS= read -r crate; do
+    last_line="$crate"
+    if [ "${crate: -5}" == ":null" ]; then
+      continue
+    fi
+    # for avoiding duplicate entries
+    local found
+    for found_crate in "${crates[@]}"; do
+      if [ "$crate" == "$found_crate" ]; then
+        found=true
+        break
+      fi
+    done
+    if [ "${found:-}" ]; then
+      unset found
+    else
+      crates+=("$crate")
+    fi
+  # dependencies with {"source": null} are the ones in this project's workspace,
+  # hence the getpath($p)==null in the jq script below
+  done < <(cargo metadata --quiet --format-version=1 | jq -r '
+    . as $in |
+    paths |
+    select(.[-1]=="source" and . as $p | $in | getpath($p)==null) as $path |
+    del($path[-1]) as $path |
+    $in | "\(getpath($path + ["name"])):\(getpath($path + ["version"]))"
+  ')
+  if [ -z "${last_line+_}" ]; then
+    die "No lines were read for cargo metadata of $PWD (some error probably occurred)"
+  fi
+
+  local update_args=()
+  for crate in "${crates[@]}"; do
+    update_args+=("-p" "$crate")
+  done
+  set -x
+  cat Cargo.toml
+  cargo update "${update_args[@]}"
+  set +x
+
+  # remove crates which weren't used in the crate graph. this is required for
+  # cargo commands which use the "--locked" flag since unused patches makes
+  # Cargo.lock become unstable.
+  local unused_dependencies
+  readarray -t unused_dependencies < <(toml \
+    get \
+    --toml-path Cargo.lock patch | \
+    jq -r '.unused | .[] | .name'
+  )
+  toml unset --toml-path Cargo.lock 'patch'
+
+  while IFS= read -r patched_repository; do
+    while IFS= read -r patched_dependency; do
+      for unused_dependency in "${unused_dependencies[@]}"; do
+        if [ "$unused_dependency" == "$patched_dependency" ]; then
+          toml unset --toml-path Cargo.toml patch "$patched_repository" "$patched_dependency"
+          continue 2
+        fi
+      done
+    done < <(toml get --toml-path Cargo.toml patch "$patched_repository" | jq -r 'keys | .[]')
+  done < <(toml get --toml-path Cargo.toml patch | jq -r 'keys | .[]')
+}
+
+replace_project_with() {
+  local source="$1"
+  local destination="$PWD"
+
+  # shellcheck disable=SC2012
+  ls -A "$destination" | while IFS= read -r file; do
+    if [ "$file" != ".git" ]; then
+      if [ -d "$file" ]; then
+        rm -rf "$file"
+      else
+        rm -f "$file"
+      fi
+    fi
+  done
+
+  >/dev/null pushd "$source"
+  # shellcheck disable=SC2012
+  ls -A "$source" | while IFS= read -r file; do
+    if [ "$file" != ".git" ]; then
+      if [ -d "$file" ]; then
+        cp -r "$file" "$destination"
+      else
+        cp "$file" "$destination"
+      fi
+    fi
+  done
+  >/dev/null popd
+}
+
+detect_dependencies_among_companions() {
+  local dir="${1:-$PWD}"
+
+  dependencies_among_companions=()
+
+  local org_crates_prefix_with_slash="${org_crates_prefix}/"
+
+  # in the past we've used cargo metadata to detect dependencies but it was
+  # finnicky since it could fail depending on the patching order
+  # see https://github.com/paritytech/pipeline-scripts/issues/49
+  while IFS= read -r line; do
+    # match git+https://github.com/org/repo?branch=master#dea1e3f5d9
+    if [ "${line::${#org_crates_prefix_with_slash}}" != "$org_crates_prefix_with_slash" ]; then
+      continue
+    fi
+
+    local after_org_prefix="${line:${#org_crates_prefix_with_slash}}"
+
+    for companion in "${companions[@]}"; do
+      # match repo?branch=master#dea1e3f5d9
+      if [ "${after_org_prefix::$(( ${#companion} + 1 ))}" == "${companion}?" ]; then
+        local found
+        for dependency_among_companions in "${dependencies_among_companions[@]}"; do
+          if [ "$dependency_among_companions" == "$companion" ]; then
+            found=true
+            break
+          fi
+        done
+        if [ "${found:-}" ]; then
+          unset found
+        else
+          dependencies_among_companions+=("$companion")
+        fi
+        continue 2
+      fi
+    done
+  done < <(toml get --toml-path "$dir/Cargo.lock" | \
+    jq -r '
+      . as $in |
+      paths(select(type=="string")) |
+      select(.[-1]=="source") as $source_path |
+      $in |
+      getpath($source_path)
+    '
+  )
+}
+
+register_used_org_dep() {
+  local hashed_files="$1"
+  local repository="$2"
+  local commit_sha="$3"
+  patched_org_deps+=(
+    "$org_crates_prefix/$repository?branch=master#"
+    "$org_github_prefix/$repository/archive/$commit_sha.tar.gz"
+    "$hashed_files"
+    "$repository"
+    "$commit_sha"
+  )
+}
+
+register_success() {
+  local dependent_repo_dir="$1"
+  local dependent_pr="$2"
+  local dependent_commit_sha="$3"
+  local jobs_url="$4"
+  local dependent_files="$5"
+
+  local cargo_lock_json
+  cargo_lock_json="$(toml get --toml-path "$dependent_repo_dir/Cargo.lock")"
+
+  local dependencies_json='{'
+  if [ ${#patched_org_deps[*]} -gt 0 ]; then
+    for ((i=0; i < ${#patched_org_deps[*]}; i+=5)); do
+      local prefix="${patched_org_deps[$i]}"
+      local url="${patched_org_deps[$((i+1))]}"
+      local files="${patched_org_deps[$((i+2))]}"
+      local repository="${patched_org_deps[$((i+3))]}"
+      local commit_sha="${patched_org_deps[$((i+4))]}"
+      dependencies_json+="$(echo -n "$prefix" | jq -sRr @json): {
+        \"url\": $(echo -n "$url" | jq -sRr @json),
+        \"files\": $(echo -n "$files" | jq -sRr @json),
+        \"repository\": $(echo -n "$repository" | jq -sRr @json),
+        \"sha\": $(echo -n "$commit_sha" | jq -sRr @json)
+      },"
+    done
+    dependencies_json="${dependencies_json:: -1}"
+  fi
+  dependencies_json+='}'
+
+  local dependent_json
+  dependent_json="{
+    \"files\": $(echo -n "$dependent_files" | jq -sRr @json),
+    \"sha\": $(echo -n "$dependent_commit_sha" | jq -sRr @json)
+  }"
+
+  local jobs_json
+  jobs_json="$(echo -n "$jobs_url" | jq -sRr @json)"
+
+  local payload="{
+    \"cargo_lock\": $cargo_lock_json,
+    \"dependencies\": $dependencies_json,
+    \"dependent\": $dependent_json,
+    \"jobs\": $jobs_json 
+  }"
+  echo "Sending payload to Redis:"$'\n'"$payload"
+
+  local key="cbs/$dependent/PR-$dependent_pr"
+  echo "Uploading payload to key $key"
+
+  # FIXME: install redis-cli in the CI image directly
+  >/dev/null apt-get update -y
+  >/dev/null apt-get install -y redis-server
+  export REDISCLI_AUTH="$GITLAB_REDIS_AUTH"
+  echo -n "$payload" | timeout 32 redis-cli \
+    -u "$GITLAB_REDIS_URI" \
+    -x SET "$key"
+  export -n REDISCLI_AUTH
+  unset REDISCLI_AUTH
+}
+
+merge_upstream() {
+  local repo="$1"
+  local dir="${2:-PWD}"
+
+  local repo_url="$org_github_prefix/$repo"
+
+  >/dev/null pushd "$dir"
+
+  echo "Merging master of $repo_url into $repo"
+  &>/dev/null git remote remove github || :
+  git remote add github "$repo_url"
+  git fetch --force github master
+  git show-ref github/master
+  if ! git merge github/master \
+    --verbose \
+    --no-edit \
+    -m "Merge master into $repo"
+  then
+    die "Unable to merge master into $repo. If Git is complaining about the commit history, it probably means that the branch is more than $dependent_git_history_depth commits behind master."
+  fi
+  git remote remove github
+
+  >/dev/null popd
+}
+
+# this function creates a Git branch with the dependent's source code patched to
+# the previously-detected dependencies, then pushes that branch to GitLab so that
+# a pipeline can be created for it
 patch_and_check_dependent() {
-  local dependent="$1"
-  local dependent_repo_dir="$2"
+  local dependent_repo_dir="$1"
+  local this_pr_number="$2"
+  local has_overridden_dependent_ref="$3"
 
-  pushd "$dependent_repo_dir" >/dev/null
+  # Throughout this function each dependency will be saved to a separate commit
+  # to be pushed to GitLab so that we'll be able to refer to them via the commit
+  # hashes, as opposed to jamming all the source code into a single directory
+  # and using relative paths. We've tried the latter, but it didn't work because
+  # Cargo considers that all relative path dependencies within a directory
+  # belong to the same workspace, which made the dependencies' Cargo.lock file
+  # become ignored.
+  # The intent is to build an orphan branch where each commit will contain the
+  # source code of a dependency used for this check. after the branch is built,
+  # it'll be pushed to gitlab so that a pipeline can be created for it, the same
+  # way that a pipeline would be created for a pull request's branch after it's
+  # mirrored via push.
 
-  if [ "${has_overridden_dependent_ref:-}" ]; then
+  # Throughout this function we need to use BOTH `diener patch` as well as
+  # `diener update` since Cargo doesn't always respect patches.
+  # - https://github.com/rust-lang/cargo/issues/6204#issuecomment-432260143
+  # - https://github.com/rust-lang/cargo/issues/6204#issuecomment-433596787
+  # > [patch] simply augments a source, it doesn't force a candidate to be used
+  # This is also corroborated by
+  # https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1664187#L754 which
+  # shows that using [patch] alone doesn't work properly.
+
+  # First of all we need to merge master into all branches involved in this
+  # procedure. This is not only for the sake of having a more robust integration
+  # which takes master's code into account, but also for making it so file
+  # contents can be leveraged for knowing if the dependents' CIs can be skipped
+  # during the companion merge sequence, as it'll be detailed below.
+  # ---
+  # For dependencies:
+  # After a PR is merged into master its commit SHA will change unpredictably,
+  # therefore we can't use the commit SHA to tell if the dependencies have
+  # changed. Knowing if dependencies have changed is relevant for clearing one
+  # of the criteria required for skipping CIs (see ./check_dependent_project_pipeline.sh)
+  # throughout the merge chain in case since, if a given repository's source -
+  # that is, not only its own source code, but also the source of its
+  # dependencies - has been tested before as a byproduct of this check, in which
+  # case it would be wasteful to run the whole CI all over again. Since the
+  # commit SHA can't be used for that comparison, as a workaround we'll compare
+  # the dependencies' source code by file contents instead. Herein lies another
+  # problem: after the dependencies' PR lands into master, their files' contents
+  # might change as a result of the merge, and those changes would get in the
+  # way of our comparison. By merging master into the dependencies we'll have a
+  # better guarantee that file content changes will happen less often, if at
+  # all, as a result of the PR being merged into master.
+  # ---
+  # For the dependent:
+  # processbot merges master into the companions before pushing their lockfile
+  # updates, so we expect the file contents to be aligned with master by the
+  # time the skip check is run
+  if [ "${IS_DEPENDENT_PIPELINE:-}" ]; then
+    echo "Skipping master merge as this is a dependent pipeline, therefore master should already have been merged into the relevant branches"
+  elif [ "$has_overridden_dependent_ref" ]; then
+    echo "Skipping master merge as the dependent repository's ref has been overridden"
+  else
+    merge_upstream "$this_repo" "$this_repo_dir"
+  fi
+
+  # hash repository contents before doing any patching since the patching
+  # procedure modifies the files
+  # note: the repository should've been merged with upstream at this point,
+  # otherwise the files' hashes won't correspond to the hashes in master after
+  # the PR is merged
+  local this_repo_files
+  this_repo_files="$(hash_git_files "$this_repo_dir")"
+
+  # hash repository contents before doing any patching since the patching
+  # procedure modifies the files
+  # note: the repository should've been merged with upstream at this point,
+  # otherwise the files' hashes won't correspond to the hashes in master after
+  # the PR is merged
+  local dependent_files
+  dependent_files="$(hash_git_files "$dependent_repo_dir")"
+
+  local patched_org_deps=()
+
+  # Start by creating the orphan branch which will be used to run the pipeline
+  # on GitLab
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  pushd "$tmp_dir" >/dev/null
+
+  local branch_name
+  if [ "${dependent_pr:-}" ]; then
+    # add the PR number at the end so that check_dependent_project can also be
+    # run for the dependent's PR after it's patched and sent to GitLab
+    branch_name="$gitlab_dependent_branch_name-CMP$dependent_pr"
+  else
+    branch_name="$gitlab_dependent_branch_name"
+  fi
+
+  git init
+  touch init
+  git add .
+  git commit -q -m "initial commit for job $CI_JOB_URL"
+  git branch -m "$branch_name"
+  git remote add gitlab \
+    "${gitlab_url_prefix}token:${gitlab_dependent_token}@${gitlab_domain}/${gitlab_dependent_path}.git"
+  local gitlab_destination="${gitlab_url_prefix}${gitlab_domain}/${gitlab_dependent_path}.git"
+
+  # discover all the crates that we have in the current repository so that we'll
+  # be able to detect if the dependent is referencing them correctly, e.g. the
+  # dependent might be incorrectly referencing a deleted crate
+  discover_our_crates "$this_repo_dir"
+
+  # Detect the companions which are a dependency of dependent; e.g. when we're
+  # running this script in Substrate and the dependent for this job is Cumulus,
+  # a Polkadot companion should be patched inside of this dependent since
+  # Cumulus depends on Polkadot
+  echo "Detected companions: ${companions[*]}"
+  detect_dependencies_among_companions "$dependent_repo_dir"
+  echo "Detected dependencies among companions: ${dependencies_among_companions[*]}"
+
+  if [ "${IS_DEPENDENT_PIPELINE:-}" ]; then
+    echo "Skipping extra_dependencies ($extra_dependencies) as this is a dependent pipeline, therefore this branch should already be patched"
+  elif [ "$has_overridden_dependent_ref" ]; then
     echo "Skipping extra_dependencies ($extra_dependencies) as the dependent repository's ref has been overridden"
   else
-    # It is necessary to patch in extra dependencies which have already been
-    # merged in previous steps of the Companion Build System's dependency chain.
-    # For instance, consider the following dependency chain:
+    # Why is $extra_dependencies necessary? For the following explanations,
+    # consider the following relationship of "dependency -> dependent":
     #     Substrate -> Polkadot -> Cumulus
-    # When this script is running for Cumulus as the dependent, on Polkadot's
-    # pipeline, it is necessary to patch the master of Substrate into this
-    # script's branches because Substrate's master will contain the pull request
-    # which was part of the dependency chain for this PR and was merged before
-    # this script gets to run for the last time (after lockfile updates and before
-    # merge).
+    # ---
+    # Reason 1 is about compatibility. When a Substrate PR has a Polkadot
+    # companion, but no Cumulus companion, Cumulus' master will be used; and
+    # since Polkadot is a dependency of Cumulus, the Polkadot companion is
+    # patched into Cumulus' master. Therefore we'd test the following
+    # integration:
+    #     Substrate PR + Polkadot PR + Cumulus master
+    # By doing that we're confirming that the Substrate PR is compatible with
+    # Cumulus' master *with* the Polkadot PR, but it *might* not be compatible
+    # without it. Let's consider the case where it isn't. After the Polkadot
+    # companion is merged, Cumulus' Polkadot dependency will not be updated
+    # because there was no Cumulus companion; that becomes a problem because
+    # Cumulus master only is compatible with Substrate because of that Polkadot
+    # PR, but it was not updated to reflect that. To solve that situation we
+    # should specify Polkadot as an "extra dependency" of Cumulus so that we'll
+    # default to using Polkadot's master when patching, which is assumed to be
+    # compatible with Substrate, instead of whatever is set in Cumulus lockfile,
+    # which might not be compatible with Substrate master after a Substrate PR
+    # with Polkadot companion and no Cumulus companion was merged, as explained
+    # above.
+    # ---
+    # Reason 2 is about merge sequences. The merge sequence for our
+    # "Substrate -> Polkadot -> Cumulus" dependency chain is as follows:
+    #     1. Merge Substrate
+    #     2. Update Substrate reference of Polkadot companion
+    #     3. Merge Polkadot companion
+    #     4. Update Substrate + Polkadot references of Cumulus companion
+    #     5. Merge Cumulus companion
+    # Let's consider that we are transitioning from Step 2 to Step 3. After
+    # updating the Substrate reference, a commit will be pushed to the Polkadot
+    # companion, which will make its CI run again, and therefore this script's
+    # would run for the companion's "Polkadot -> Cumulus" integration job
+    # (currently called check-dependent-cumulus). Since on Step 2 we have not
+    # yet updated the Substrate references of the Cumulus companion (as that
+    # only happens on Step 4), the Cumulus companion *might* not be compatible
+    # with the Polkadot companion because its Substrate reference is outdated.
+    # To solve that situation we should specify Substrate as an "extra
+    # dependency" of Cumulus so that we'll default to using Substrate master
+    # when patching, which is assumed to be compatible with the Polkadot
+    # companion used in that job.
     for extra_dependency in $extra_dependencies; do
       if [ "$extra_dependency" = "$this_repo" ]; then
         echo "Skipping extra dependency $extra_dependency because this branch (also $this_repo) will be patched into the dependent $dependent"
         continue
       fi
 
-      if [ "$extra_dependency" = "$dependent_repo" ]; then
-        echo "Skipping extra dependency $extra_dependency because it's being targetted as a dependent for this script"
+      if [ "$extra_dependency" = "$dependent" ]; then
+        echo "Skipping extra dependency $extra_dependency because it's being targeted as a dependent for this script"
         continue
       fi
 
       # check if a repository specified in $extra_dependencies but is also
-      # specified as a companion (e.g. a Substrate PR whose
-      # check-dependent-cumulus job specifies `EXTRA_DEPENDENCIES: polkadot` but
-      # also a `polkadot companion: something` in its description); in that case
+      # specified as a companion, e.g. a Substrate PR whose
+      # check-dependent-cumulus job specifies `EXTRA_DEPENDENCIES: polkadot` and
+      # also a `polkadot companion: something` in its description; in that case
       # skip this step because that repository will be patched later
-      for companion in "${companions[@]}"; do
+      for companion in "${dependencies_among_companions[@]}"; do
         if [ "$companion" = "$extra_dependency" ]; then
           echo "Skipping extra dependency $extra_dependency because it was specified as a companion"
           continue 2
@@ -372,102 +806,278 @@ patch_and_check_dependent() {
         "$org_github_prefix/$extra_dependency.git" \
         "$extra_dependencies_dir/$extra_dependency"
 
+      >/dev/null pushd "$extra_dependencies_dir/$extra_dependency"
+      local upstream_extra_dependency_commit_sha
+      upstream_extra_dependency_commit_sha="$(git rev-parse HEAD)"
+      >/dev/null popd
+      register_used_org_dep \
+        "$(hash_git_files "$extra_dependencies_dir/$extra_dependency")" \
+        "$extra_dependency" \
+        "$upstream_extra_dependency_commit_sha"
+
+      replace_project_with "$extra_dependencies_dir/$extra_dependency"
+      git add .
+      git commit \
+        -q \
+        -m "commit extra dependency $extra_dependency (default branch, $upstream_extra_dependency_commit_sha)"
+      local extra_dependency_commit_sha
+      extra_dependency_commit_sha="$(git rev-parse HEAD)"
+      echo "Pushing extra dependency $extra_dependency as commit $extra_dependency_commit_sha"
+      git push --force -o ci.skip gitlab HEAD
+
       echo "Patching extra dependency $extra_dependency into $this_repo_dir"
+      diener update \
+        "--$extra_dependency" \
+        --git "$gitlab_destination" \
+        --rev "$extra_dependency_commit_sha" \
+        --path "$this_repo_dir"
       diener patch \
         --target "$org_github_prefix/$extra_dependency" \
+        --point-to-git "$gitlab_destination" \
+        --point-to-git-commit "$extra_dependency_commit_sha" \
         --crates-to-patch "$extra_dependencies_dir/$extra_dependency" \
         --path "$this_repo_dir/Cargo.toml"
 
       echo "Patching extra dependency $extra_dependency into $dependent_repo_dir"
+      diener update \
+        "--$extra_dependency" \
+        --git "$gitlab_destination" \
+        --rev "$extra_dependency_commit_sha" \
+        --path "$dependent_repo_dir"
       diener patch \
         --target "$org_github_prefix/$extra_dependency" \
+        --point-to-git "$gitlab_destination" \
+        --point-to-git-commit "$extra_dependency_commit_sha" \
         --crates-to-patch "$extra_dependencies_dir/$extra_dependency" \
-        --path Cargo.toml
+        --path "$dependent_repo_dir/Cargo.toml"
     done
   fi
+
+  replace_project_with "$this_repo_dir"
+  git add .
+  git commit -q -m "commit dependency $this_repo (PR $this_pr_number, upstream commit $CI_COMMIT_SHA)"
+  local this_repo_commit_sha
+  this_repo_commit_sha="$(git rev-parse HEAD)"
+  echo "Pushing $this_repo as commit $this_repo_commit_sha"
+  git push --force -o ci.skip gitlab HEAD
 
   # Patch this repository (the dependency) into the dependent for the sake of
   # being able to test how the dependency graph will behave after the merge
   echo "Patching $this_repo into $dependent"
+  diener update \
+    "--$this_repo" \
+    --git "$gitlab_destination" \
+    --rev "$this_repo_commit_sha" \
+    --path "$dependent_repo_dir"
   diener patch \
     --target "$org_github_prefix/$this_repo" \
+    --point-to-git "$gitlab_destination" \
+    --point-to-git-commit "$this_repo_commit_sha" \
     --crates-to-patch "$this_repo_dir" \
-    --path Cargo.toml
-
-  # The next step naturally only makes sense if a companion PR was specified for
-  # the dependent being targeted by this check, because then processbot will be
-  # able to push the lockfile updates to that PR while taking into account
-  # dependencies among companions; without a companion PR for the dependent,
-  # the dependent's lockfile would not be updated at the end of the merge chain
-  # due to the lack of a companion PR (which those lockfile updates would be
-  # pushed to), thus leaving the dependent's repository desynchronized.
-  # The above problem can be worked around by specifying a dependency in
-  # $EXTRA_DEPENDENCIES which takes care of using a dependency's master branch
-  # in place of a companion in case a companion for that dependency was not
-  # specified, as described in
-  # https://github.com/paritytech/substrate/pull/11280#issue-1214392074.
+    --path "$dependent_repo_dir/Cargo.toml"
+  register_used_org_dep \
+    "$this_repo_files" \
+    "$this_repo" \
+    "$CI_COMMIT_SHA"
 
   # Each companion dependency is also patched into the dependent so that the
   # dependency graph becomes how it should end up after all PRs are merged.
-  for comp in "${companions[@]}"; do
-    if [ "$comp" = "$dependent_repo" ]; then
+  for comp in "${dependencies_among_companions[@]}"; do
+    if [ "$comp" = "$dependent" ]; then
       continue
     fi
 
+    >/dev/null pushd "$companions_dir/$comp"
+    local upstream_companion_commit_sha
+    upstream_companion_commit_sha="$(git symbolic-ref --short HEAD)"
+    >/dev/null popd
+    register_used_org_dep \
+      "$(hash_git_files "$companions_dir/$comp")" \
+      "$comp" \
+      "$upstream_companion_commit_sha"
+
     echo "Patching $this_repo into the $comp companion, which could be a dependency of $dependent, assuming that $comp also depends on $this_repo. Reasoning: if a companion was referenced in this PR or a companion of this PR, then it probably has a dependency on this PR, since PR descriptions are processed starting from the dependencies."
+    diener update \
+      "--$this_repo" \
+      --git "$gitlab_destination" \
+      --rev "$this_repo_commit_sha" \
+      --path "$companions_dir/$comp"
     diener patch \
       --target "$org_github_prefix/$this_repo" \
+      --point-to-git "$gitlab_destination" \
+      --point-to-git-commit "$this_repo_commit_sha" \
       --crates-to-patch "$this_repo_dir" \
       --path "$companions_dir/$comp/Cargo.toml"
 
+    replace_project_with "$companions_dir/$comp"
+    git add .
+    git commit \
+      -q \
+      -m "commit companion $comp (upstream commit $upstream_companion_commit_sha)"
+    local companion_commit_sha
+    companion_commit_sha="$(git rev-parse HEAD)"
+    echo "Pushing companion $companion as commit $companion_commit_sha"
+    git push --force -o ci.skip gitlab HEAD
+
     echo "Patching $comp companion into $dependent"
+    diener update \
+      "--$comp" \
+      --git "$gitlab_destination" \
+      --rev "$companion_commit_sha" \
+      --path "$dependent_repo_dir"
     diener patch \
       --target "$org_github_prefix/$comp" \
+      --point-to-git "$gitlab_destination" \
+      --point-to-git-commit "$companion_commit_sha" \
       --crates-to-patch "$companions_dir/$comp" \
-      --path Cargo.toml
+      --path "$dependent_repo_dir/Cargo.toml"
   done
+
+  replace_project_with "$dependent_repo_dir"
 
   # Match the crates *AFTER* patching for verifying that dependencies which are
   # removed in this pull request have been pruned properly from the dependent.
-  # It does not make sense to do this before patching since the dependency graph
-  # would not yet how be how it should become after all merges are finished.
+  # It does not make sense to do this before patching because the dependency
+  # graph then doesn't match it'll end up after merge.
   match_dependent_crates "$dependent"
 
-  eval "${COMPANION_CHECK_COMMAND:-cargo check --all-targets --workspace}"
+  echo "Updating local crates after patching"
+  update_local_crates "$gitlab_destination"
 
-  popd >/dev/null
+  >/dev/null pushd "$dependent_repo_dir"
+  local upstream_dependent_commit_sha
+  upstream_dependent_commit_sha="$(git symbolic-ref --short HEAD)"
+  >/dev/null popd
+
+  git add .
+  git commit \
+    -q \
+    -m "commit dependent $dependent (upstream commit $upstream_dependent_commit_sha)"
+  echo "Pushing dependent $dependent to GitLab as the last commit"
+  git push --force -o ci.skip gitlab HEAD
+
+  printf -v gitlab_dependent_path_encoded %s "$(echo -n "$gitlab_dependent_path" | jq -sRr @uri)"
+
+  local gitlab_projects_api="${gitlab_url_prefix}${gitlab_domain}/api/v4/projects"
+
+  # SKIP_DEPENDENTS: the companions detected in this PR will be tested within
+  # the pipeline for this job, therefore it doesn't make sense to also test
+  # inside of each dependent pipeline
+  # IS_DEPENDENT_PIPELINE: signal that this job belongs to a dependent pipeline,
+  # which skips some of the steps in the patching procedure in that pipeline's
+  # branch is already is patched
+  local pipeline_creation_payload
+  pipeline_creation_payload="{
+    \"ref\": $(echo -n "$branch_name" | jq -sRr @json),
+    \"variables\": [
+      { \"key\": \"SKIP_DEPENDENTS\", \"value\": \"${companions[*]}\" },
+      { \"key\": \"IS_DEPENDENT_PIPELINE\", \"value\": \"true\" }
+    ]
+  }"
+  echo "pipeline_creation_payload: $pipeline_creation_payload"
+
+  local pipeline_id project_id
+  local pipeline_creation_url="$gitlab_projects_api/$gitlab_dependent_path_encoded/pipeline"
+  IFS=$'\n' read -d '\n' -r pipeline_id project_id < <(logged_curl \
+    "$pipeline_creation_url" \
+    -sSL \
+    -H "PRIVATE-TOKEN: $gitlab_dependent_token" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -X POST \
+    -d "$pipeline_creation_payload" | \
+    jq -e -r ".id, .project_id"
+  ) || :
+  if [ "${pipeline_id:-null}" == null ]; then
+    die "Failed to fetch pipeline id from $pipeline_creation_url"
+  fi
+  if [ "${project_id:-null}" == null ]; then
+    die "Failed to fetch project id from $pipeline_creation_url"
+  fi
+
+  local pipeline_poll_errors=0
+  local pipeline_poll_error_limit=2
+  local pipeline_poll_url="$gitlab_projects_api/$project_id/pipelines/$pipeline_id"
+  local pipeline_poll_delay=60
+  while true; do
+    IFS= read -r pipeline_status < <(logged_curl \
+      "$pipeline_poll_url" \
+      -sSL \
+      -H "PRIVATE-TOKEN: $gitlab_dependent_token" | \
+      jq -e -r ".status"
+    ) || :
+    if [ "$pipeline_status" ]; then
+      pipeline_poll_errors=0
+      case "$pipeline_status" in
+        success)
+          echo "Pipeline $pipeline_poll_url succeeded with status: $pipeline_status"
+          if [ "${dependent_pr:-}" ]; then
+            # failures are ignored for this command because we shouldn't fail
+            # the job in case some external problem happens, e.g. Redis being
+            # down, as the purpose of this step is merely optimization
+            # TODO: connect failures here to some error reporting system so that
+            # we'll be aware of this command's failures
+            register_success \
+              "$dependent_repo_dir" \
+              "$dependent_pr" \
+              "$upstream_dependent_commit_sha" \
+              "$pipeline_poll_url/jobs" \
+              "$dependent_files" || :
+          fi
+          exit 0
+        ;;
+        skipped|canceled|failed)
+          die "Pipeline $pipeline_poll_url failed with status: $pipeline_status"
+        ;;
+        *)
+          echo "Current pipeline status is: $pipeline_status"
+        ;;
+      esac
+    else
+      ((pipeline_poll_errors++))
+      if [ "$pipeline_poll_errors" -gt $pipeline_poll_error_limit ]; then
+        die "Request to $pipeline_poll_url failed more than $pipeline_poll_error_limit times"
+      fi
+    fi
+    echo "Requesting $pipeline_poll_url again in $pipeline_poll_delay seconds..."
+    sleep $pipeline_poll_delay
+  done
+
+  >/dev/null popd
 }
 
 main() {
-  if ! [[ "$CI_COMMIT_REF_NAME" =~ ^[[:digit:]]+$ ]]; then
-    die "\"$CI_COMMIT_REF_NAME\" was not recognized as a pull request ref"
-  fi
+  for skipped_dependent in ${SKIP_DEPENDENTS:-}; do
+    if [ "$skipped_dependent" == "$dependent" ]; then
+      echo "Skipping $dependent since it was found in \$SKIP_DEPENDENTS ($SKIP_DEPENDENTS)"
+      exit 0
+    fi
+  done
 
   # Set the user name and email to make merging work
-  git config --global user.name 'CI system'
-  git config --global user.email '<>'
-  git config --global pull.rebase false
+  if [ "${CI:-}" ]; then
+    git config --global user.name "Companion Build System (CBS)"
+    git config --global user.email "<>"
+    git config --global pull.rebase false
+  fi
 
   # process_pr_description calls itself for each companion in the description on
   # each detected companion PR, effectively considering all companion references
   # on all PRs
-  process_pr_description "$this_repo" "$CI_COMMIT_REF_NAME"
+  process_pr_description "$this_repo" "$this_pr_number"
 
-  # This PR might be targetting a custom ref (i.e. not master) through companion
-  # overrides from --companion-overrides or the PR's description, in which case
-  # it won't be proper to merge master (since it's not targetting master) before
-  # performing the companion checks
-  local dependent_repo_dir="$companions_dir/$dependent_repo"
+  local has_overridden_dependent_ref
+  local dependent_repo_dir="$companions_dir/$dependent"
   if ! [ -e "$dependent_repo_dir" ]; then
     local dependent_clone_options=(
-      --depth=1
+      --depth="$dependent_git_history_depth"
     )
 
     if [ "${pr_target_branch[$this_repo]}" == "master" ]; then
-      echo "Cloning dependent $dependent_repo directly as it was not detected as a companion"
-    elif [ "${companion_branch_override[$dependent_repo]:-}" ]; then
-      echo "Cloning dependent $dependent_repo with branch ${companion_branch_override[$dependent_repo]} from manual override"
-      dependent_clone_options+=("--branch" "${companion_branch_override[$dependent_repo]}")
+      echo "Cloning dependent $dependent directly as it was not detected as a companion"
+    elif [ "${companion_branch_override[$dependent]:-}" ]; then
+      echo "Cloning dependent $dependent with branch ${companion_branch_override[$dependent]} from manual override"
+      dependent_clone_options+=("--branch" "${companion_branch_override[$dependent]}")
       has_overridden_dependent_ref=true
     else
       for override in "${companion_overrides[@]}"; do
@@ -480,7 +1090,7 @@ main() {
             if [[ "$this_repo_override" =~ ^(.*)\* ]]; then
               this_repo_override_prefix="${BASH_REMATCH[1]}"
             fi
-          elif [[ "$line" =~ ^[[:space:]]*$dependent_repo:[[:space:]]*(.*) ]]; then
+          elif [[ "$line" =~ ^[[:space:]]*$dependent:[[:space:]]*(.*) ]]; then
             dependent_repo_override="${BASH_REMATCH[1]}"
             if [[ "$dependent_repo_override" =~ ^(.*)\* ]]; then
               dependent_repo_override_prefix="${BASH_REMATCH[1]}"
@@ -495,10 +1105,10 @@ main() {
           continue
         fi
 
-        echo "Detected override $this_repo_override for $this_repo and override $dependent_repo_override for $dependent_repo"
+        echo "Detected override $this_repo_override for $this_repo and override $dependent_repo_override for $dependent"
 
         local base_ref_prefix="${this_repo_override_prefix:-$this_repo_override}"
-        if [ "${pr_target_branch[$this_repo]:0:${#base_ref_prefix}}" != "$base_ref_prefix" ]; then
+        if [ "${pr_target_branch[$this_repo]::${#base_ref_prefix}}" != "$base_ref_prefix" ]; then
           continue
         fi
 
@@ -515,14 +1125,14 @@ main() {
         ]]; then
           branch_name="${dependent_repo_override_prefix}${this_repo_override_suffix}"
 
-          echo "Checking if $branch_name exists in $dependent_repo"
+          echo "Checking if $branch_name exists in $dependent"
           local response_code
           response_code="$(curl \
             -o /dev/null \
             -sSL \
             -H "Authorization: token $github_api_token" \
             -w '%{response_code}' \
-            "$github_api/repos/$org/$dependent_repo/branches/$branch_name"
+            "$github_api/repos/$org/$dependent/branches/$branch_name"
           )"
 
           # Sometimes the target branch found via override does not *yet* exist
@@ -533,10 +1143,10 @@ main() {
           # When that happens, the script has no choice other than *guess* the
           # a replacement branch to be used for the inexistent branch.
           if [ "$response_code" -eq 200 ]; then
-            echo "Branch $branch_name exists in $dependent_repo. Proceeding..."
+            echo "Branch $branch_name exists in $dependent. Proceeding..."
           else
-            echo "Branch $branch_name doesn't exist in $dependent_repo (status code $response_code)"
-            echo "Fetching the list of branches in $dependent_repo to find a suitable replacement..."
+            echo "Branch $branch_name doesn't exist in $dependent (status code $response_code)"
+            echo "Fetching the list of branches in $dependent to find a suitable replacement..."
 
             # The guessing for a replacement branch works by taking the most
             # recently updated branch (ordered by commit date) which follows the
@@ -546,8 +1156,8 @@ main() {
             # be polkadot-v0.9.19 as of this writing.
             local replacement_branch_name
             while IFS= read -r line; do
-              echo "Got candidate branch $line in $dependent_repo's refs"
-              if [ "${line:0:${#dependent_repo_override_prefix}}" == "$dependent_repo_override_prefix" ]; then
+              echo "Got candidate branch $line in $dependent's refs"
+              if [ "${line::${#dependent_repo_override_prefix}}" == "$dependent_repo_override_prefix" ]; then
                 echo "Found candidate branch $line as the replacement of $branch_name"
                 replacement_branch_name="$line"
                 break
@@ -558,7 +1168,7 @@ main() {
               "$(
                 ghgql_most_recent_branches_query \
                   "$org" \
-                  "$dependent_repo" \
+                  "$dependent" \
                   "$dependent_repo_override_prefix"
               )" | jq -r '.data.repository.refs.edges[].node.name'
             )
@@ -568,7 +1178,7 @@ main() {
               branch_name="$replacement_branch_name"
               unset replacement_branch_name
             else
-              die "Unable to find the replacement for inexistent branch $branch_name of $dependent_repo"
+              die "Unable to find the replacement for inexistent branch $branch_name of $dependent"
             fi
           fi
         else
@@ -576,40 +1186,37 @@ main() {
         fi
         dependent_clone_options+=("$branch_name")
 
-        echo "Setting up the clone of $dependent_repo with options: ${dependent_clone_options[*]}"
+        echo "Setting up the clone of $dependent with options: ${dependent_clone_options[*]}"
         has_overridden_dependent_ref=true
 
         break
       done
     fi
 
-    dependent_repo_dir="$this_repo_dir/$dependent_repo"
-    # shellcheck disable=SC2068
     git clone \
-      ${dependent_clone_options[@]} \
-      "$org_github_prefix/$dependent_repo.git" \
+      "${dependent_clone_options[@]}" \
+      "$org_github_prefix/$dependent.git" \
       "$dependent_repo_dir"
+
+    >/dev/null pushd "$dependent_repo_dir"
+    local head_sha
+    head_sha="$(git rev-parse HEAD)"
+    git branch -m "$head_sha"
+    echo "Cloned dependent $dependent's default branch at commit $head_sha"
+    >/dev/null popd
+
+    merge_upstream "$dependent" "$dependent_repo_dir"
   fi
 
-  if [ "${has_overridden_dependent_ref:-}" ]; then
-    echo "Skipping master merge of $this_repo as the dependent repository's ref has been overridden"
-  else
-    # Merge master into this branch so that we have a better expectation of the
-    # integration still working after this PR lands.
-    # Since master's HEAD is being merged here, at the start the dependency chain,
-    # the same has to be done for all the companions because they might have
-    # accompanying changes for the code being brought in.
-    git fetch --force origin master
-    git show-ref origin/master
-    echo "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
-    git merge origin/master \
-      --verbose \
-      --no-edit \
-      -m "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
-  fi
+  # FIXME: install toml-cli in the CI image directly
+  export PIP_ROOT_USER_ACTION=ignore
+  python3 -m pip install -q --upgrade pip
+  python3 -m pip install -q --upgrade setuptools
+  python3 -m pip install -q git+https://github.com/paritytech/toml-cli.git
 
-  discover_our_crates
-
-  patch_and_check_dependent "$dependent_repo" "$dependent_repo_dir"
+  patch_and_check_dependent \
+    "$dependent_repo_dir" \
+    "$this_pr_number" \
+    "${has_overridden_dependent_ref:-}"
 }
 main

--- a/check_dependent_project_pipeline.sh
+++ b/check_dependent_project_pipeline.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+
+# This script checks if a PR, for which the dependent pipeline has been run
+# before (./check_dependent_project.sh), can be skipped based on data stored on
+# Redis.
+
+# We are unable to decide on whether to skip or not based on dependencies'
+# commit SHAs alone because their master's HEAD commit SHA is not the same as
+# the PRs' commit SHAs using during the patching procedure. Since commit SHAs
+# can't be relied upon, we instead compare the dependencies by their file
+# contents and permission bits.
+
+# After validating that a pipeline has already passed for this PR, this script
+# creates files for each passed job within --artifacts-path. Those files can be
+# used within subsequent jobs to hint at if they need to be run again or not.
+
+set -eu -o pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
+if [[
+  # PRs mirrored to GitLab
+  "${CI_COMMIT_REF_NAME:-}" =~ ^[[:digit:]]+$
+]]; then
+  this_pr_number=$CI_COMMIT_REF_NAME
+else
+  echo "\$CI_COMMIT_REF_NAME was not recognized as a pull request ref: ${CI_COMMIT_REF_NAME:-}"
+  exit 0
+fi
+
+get_arg required --artifacts-path "$@"
+artifacts_path="$out"
+
+tmp_files=()
+cleanup() {
+  exit_code=$?
+  rm -rf "${tmp_files[@]}"
+  exit $exit_code
+}
+trap cleanup EXIT
+
+git_dir="$PWD/.git"
+cloned_repositories="$git_dir/cbs/cloned_repositories"
+tmp_files+=("$cloned_repositories")
+
+get_pr_info_field() {
+  local prefix="$1"
+  local field="$2"
+  echo -n "$pr_info" | jq -r --arg prefix "$prefix" ".dependencies | .[\"$prefix\"] | .$field"
+}
+
+validate_repository() {
+  local repository="$1"
+  local current_sha="$2"
+  local patched_sha="$3"
+  local patched_sha_files="$4"
+  local dir="${5:-$PWD}"
+
+  echo "Comparing files of $repository at commit sha $current_sha with what was used during the patching procedure (commit sha $patched_sha merged with master)"
+
+  local patched_items=()
+  while IFS= read -r line; do
+    if ! [[ "$line" =~ ^([^[:space:]]+)[[:space:]]+([^[:space:]]+)[[:space:]]+(.*)$ ]]; then
+      die "Line of patched items had unexpected format: $line"
+    fi
+    local mode="${BASH_REMATCH[1]}"
+    local hash="${BASH_REMATCH[2]}"
+    local file="${BASH_REMATCH[3]}"
+    echo "Parsed mode $mode, hash $hash, file $file from patched files line: $line"
+
+    patched_items+=("$file" "$mode" "$hash")
+  done < <(echo "$patched_sha_files")
+
+  while IFS= read -r line; do
+    if ! [[ "$line" =~ ^([^[:space:]]+)[[:space:]]+([^[:space:]]+)[[:space:]]+(.*)$ ]]; then
+      die "Line of current items unexpected format: $line"
+    fi
+    local mode="${BASH_REMATCH[1]}"
+    local hash="${BASH_REMATCH[2]}"
+    local file="${BASH_REMATCH[3]}"
+    echo "Parsed mode $mode, hash $hash, file $file from current files line: $line"
+
+    local found
+    for ((i=0; i < ${#patched_items[@]}; i+=3)); do
+      local patched_file="${patched_items[$i]}"
+      if [ "$file" != "$patched_file" ]; then
+        continue
+      fi
+
+      local patched_mode="${patched_items[$((i+1))]}"
+      if [ "$patched_mode" != "$mode" ]; then
+        die "File changed its mode from $patched_mode to $mode: $file"
+      fi
+
+      local patched_hash="${patched_items[$((i+2))]}"
+      if [ "$hash" != "$patched_hash" ]; then
+        die "File changed its hash from $patched_hash to $hash: $file"
+      fi
+
+      found=true
+      break
+    done
+
+    if [ "${found:-}" ]; then
+      unset found
+    else
+      die "File was not found within the patched files: $file"
+    fi
+  done < <(hash_git_files "$dir")
+}
+
+validate_previous_pipeline() {
+  local pr_info="$1"
+
+  validate_repository \
+    "$CI_PROJECT_NAME" \
+    "$CI_COMMIT_SHA" \
+    "$(echo -n "$pr_info" | jq -r ".dependent | .sha")" \
+    "$(echo -n "$pr_info" | jq -r ".dependent | .files")"
+
+  local cbs_dependencies_prefixes
+  readarray -t cbs_dependencies_prefixes <<< "$(echo -n "$pr_info" | jq -r '.dependencies | keys | .[]')"
+
+  local used_cbs_dependencies_prefixes=()
+  local name version source
+
+  local nonpatched_dependencies=()
+  local next=name
+  while IFS= read -r line; do
+    case "$next" in
+      name)
+        name="$line"
+        next=version
+      ;;
+      version)
+        version="$line"
+        next=source
+      ;;
+      source)
+        source="$line"
+        next=name
+
+        for cbs_dependency_prefix in "${cbs_dependencies_prefixes[@]}"; do
+          if [ "${source::${#cbs_dependency_prefix}}" != "$cbs_dependency_prefix"  ]; then
+            continue
+          fi
+
+          local prefix="$cbs_dependency_prefix"
+          local sha="${source:${#cbs_dependency_prefix}}"
+
+          for ((i=0; i < ${#used_cbs_dependencies_prefixes[*]}; i+=2)); do
+            local used_prefix="${used_cbs_dependencies_prefixes[$i]}"
+            if [ "$used_prefix" == "$prefix" ]; then
+              local used_sha="${used_cbs_dependencies_prefixes[$((i+1))]}"
+              if [ "$used_sha" != "$sha" ]; then
+                die "Dependency sources for prefix \"$prefix\" are different: found one which ends with \"$used_sha\" and another which ends with \"$sha\"."
+              fi
+            fi
+          done
+
+          used_cbs_dependencies_prefixes+=("$prefix" "$sha")
+          continue 2
+        done
+
+        nonpatched_dependencies+=("$name" "$version" "$source")
+      ;;
+    esac
+  done < <(toml get --toml-path Cargo.lock | \
+    jq -r "
+      .package |
+      .[] |
+      [ .name, .version, .source ] |
+      .[]
+    "
+  ) || :
+
+  local next=name
+  while IFS= read -r line; do
+    case "$next" in
+      name)
+        name="$line"
+        next=version
+      ;;
+      version)
+        version="$line"
+        next=source
+      ;;
+      source)
+        source="$line"
+        next=name
+
+        for ((i=0; i < ${#used_cbs_dependencies_prefixes[*]}; i+=2)); do
+          local prefix="${used_cbs_dependencies_prefixes[$i]}"
+          if [ "${source::${#prefix}}" == "$prefix" ]; then
+            echo "Dependency $name $version (from $source) will not be matched because its prefix is \"$prefix\", which was used for a dependency patch"
+            continue 2
+          fi
+        done
+
+        local found
+        for ((i=0; i < ${#nonpatched_dependencies[*]}; i+=3)); do
+          local our_dep_name="${nonpatched_dependencies[$i]}"
+          if [ "$our_dep_name" != "$name" ]; then
+            continue
+          fi
+
+          local our_dep_version="${nonpatched_dependencies[$((i+1))]}"
+          if [ "$our_dep_version" != "$version" ]; then
+            continue
+          fi
+
+          local our_dep_source="${nonpatched_dependencies[$((i+2))]}"
+          if [ "$our_dep_source" != "$source" ]; then
+            continue
+          fi
+
+          found=true
+          break
+        done
+
+        if [ "${found:-}" ]; then
+          unset found
+        else
+          local msg="The following crate was not found in \$pr_info's packages"
+          msg+=$'\n'"Name: $name"
+          msg+=$'\n'"Version: $version"
+          msg+=$'\n'"Source: $source"
+          die "$msg"
+        fi
+      ;;
+    esac
+  done < <(echo -n "$pr_info" | \
+    jq -r "
+      .cargo_lock |
+      .package |
+      .[] |
+      [ .name, .version, .source ] |
+      .[]
+    "
+  ) || :
+
+  for ((i=0; i < ${#used_cbs_dependencies_prefixes[*]}; i+=2)); do
+    local prefix="${used_cbs_dependencies_prefixes[$i]}"
+    local sha="${used_cbs_dependencies_prefixes[$((i+1))]}"
+
+    local repository
+    repository="$(get_pr_info_field "$prefix" repository)"
+
+    local cloned_repository="$cloned_repositories/$repository/$sha"
+    if ! [ -e "$cloned_repository" ]; then
+      mkdir -p "$cloned_repository"
+    fi
+
+    local url
+    url="$(get_pr_info_field "$prefix" url)"
+    >/dev/null pushd "$cloned_repository"
+    curl -sSL "$url" | tar xz --strip=1
+    # initialize the downloaded folder as a git repository because GitHub
+    # archives don't include the .git folder
+    git init --quiet
+    git add .
+    git commit -q -m "$sha"
+    >/dev/null popd
+
+    validate_repository \
+      "$repository" \
+      "$sha" \
+      "$(get_pr_info_field "$prefix" sha)" \
+      "$(get_pr_info_field "$prefix" files)" \
+      "$cloned_repository"
+  done
+}
+
+register_success() {
+  local pr_info="$1"
+
+  local jobs_url
+  jobs_url="$(echo -n "$pr_info" | jq -r ".jobs")"
+
+  local passed_jobs_dir="$artifacts_path/cbs/passed-jobs"
+  mkdir -p "$passed_jobs_dir"
+  while IFS= read -r passed_job; do
+    touch "$passed_jobs_dir/$passed_job"
+  done < <(curl -sSL "$jobs_url" | jq -r '.[] | select(.status=="success") | .name')
+}
+
+main() {
+  if [ "${CI:-}" ]; then
+    git config --global user.name "Companion Build System (CBS)"
+    git config --global user.email "<>"
+    git config --global pull.rebase false
+  fi
+
+  local pr_info_key="cbs/$CI_PROJECT_NAME/PR-$this_pr_number"
+  echo "Fetching pr_info from $pr_info_key"
+
+  # FIXME: install redis-cli in the CI image directly
+  >/dev/null apt-get update -y
+  >/dev/null apt-get install -y redis-server
+  export REDISCLI_AUTH="$GITLAB_REDIS_AUTH"
+
+  local pr_info
+  pr_info="$(timeout 32 redis-cli -u "$GITLAB_REDIS_URI" GET "$pr_info_key")"
+
+  if [ "$pr_info" ]; then
+    echo "pr_info: $pr_info"
+  else
+    die "pr_info is empty"
+  fi
+
+  # FIXME: install toml-cli in the CI image directly
+  export PIP_ROOT_USER_ACTION=ignore
+  python3 -m pip install -q --upgrade pip
+  python3 -m pip install -q --upgrade setuptools
+  python3 -m pip install -q git+https://github.com/paritytech/toml-cli.git
+
+  validate_previous_pipeline "$pr_info" && register_success "$pr_info"
+
+  export -n REDISCLI_AUTH
+}
+
+main

--- a/docs/dependent-check.md
+++ b/docs/dependent-check.md
@@ -1,0 +1,208 @@
+# Companion Build System Dependent Check V2
+
+See the example PRs for a demonstration: https://github.com/paritytech/substrate/pull/11765
+
+Cumulus integration
+  - check-dependent-cumulus: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1701832
+  - Patched branch: https://gitlab.parity.io/parity/mirrors/cumulus/-/commits/3f68bccfbbc22a5b1ef7d047739da784b6ddf4c2/
+  - Pipeline: https://gitlab.parity.io/parity/mirrors/cumulus/-/pipelines/204815
+
+Polkadot integration
+  - check-dependent-polkadot: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1701831
+  - Patched branch: https://gitlab.parity.io/parity/mirrors/polkadot/-/commits/52f1f7a0803dd85b52cdce14ad30f8943b3f4f59/
+  - Pipeline: https://gitlab.parity.io/parity/mirrors/polkadot/-/pipelines/204813
+
+# TOC
+
+- [Introduction](#introduction)
+- [Summary](#summary)
+  - [Patched code](#summary-patched-code)
+  - [What is tested by the check](#summary-what-is-tested)
+- [Example scenario: Substrate -> Polkadot -> Cumulus](#s-p-c-example)
+  - [Walkthrough](#s-p-c-example-walkthrough)
+    - [Old](#s-p-c-example-walkthrough-old)
+    - [New](#s-p-c-example-walkthrough-new)
+  - [Aftermath](#s-p-c-example-aftermath)
+- [Setup](#setup)
+- [Future work](#future-work)
+
+# Introduction <a name="introduction"></a>
+
+This document focuses on the "how", but not the "why", behind the upcoming
+changes to the Companion Build System Dependent Check (namely
+`./check_dependent_project.sh`).
+
+We suggest to start by this document to gain an understanding of the system's
+intended behavior - the "how". The code itself has comments explaining the
+decision-making behind its features - the "why".
+
+Note: The scope for the upcoming changes was built according to the plan of
+"Deliverable 1" and "Deliverable 2" of
+https://github.com/paritytech/ci_cd/issues/234#issuecomment-1160141699.
+
+# Summary <a name="summary"></a>
+
+The system has the same goals as the previous one, but it differs how the
+patched code is used and what is tested by the check.
+
+To know how it's supposed to work in practice read both the
+([example scenario](#substrate-polkadot-cumulus-example)) as well as its
+([aftermath](#substrate-polkadot-cumulus-aftermath)). The intention of this document is not to explain the decision behind how it works
+
+### Patched code <a name="summary-patched-code"></a>
+
+**Before** we `cargo check` for the patched code directly inside of the CI job.
+
+**Now** we'll instead commit the patched code to a branch which will be pushed
+to GitLab for running the full pipeline for a given dependent.
+
+---
+
+A noteworthy side-effect of this change is that **before** we were cloning all
+the projects into a single local directory, which resulted in them being patched
+as relative *path dependencies*. This transformation unintentionally made all
+projects become part of the same workspace for Cargo, as described in
+https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspace-section.
+
+> All path dependencies residing in the workspace directory automatically become members.
+
+That Cargo feature made the Cargo.lock of some projects be disregarded since
+only one Cargo.lock is considered per workspace. This behavior sometimes
+obscured problem which wouldn't be caught easily until the merge went through.
+
+**Now** we're referring to each dependency by their commit hashes, which means
+that all Cargo.lock files used within the patching procedure are properly
+considered and should be valid in tandem.
+
+### What is tested by the check <a name="summary-what-is-tested"></a>
+
+Before we were limited to `cargo check`
+
+# Example scenario: Substrate -> Polkadot -> Cumulus <a name="s-p-c-example"></a>
+
+## Walkthrough <a name="s-p-c-example-walkthrough"></a>
+
+This scenario is triggered when a Substrate PR refers to Polkadot and Cumulus
+companions in its description, e.g.
+
+```
+polkadot companion: polkadot#123
+cumulus companion: cumulus#123
+```
+
+Conditions:
+
+- The check is running for a Substrate PR
+- The Substrate PR has a Polkadot companion: `polkadot#123`
+- The Substrate PR has a Cumulus companion: `cumulus#123`
+- The CI job we're running is `check-dependent-cumulus`, i.e. we're testing the
+  *direct* integration between Substrate and Cumulus; however, since a Polkadot
+  companion is specified, and Polkadot is a dependency of Cumulus, the Polkadot
+  companion is taken into account for this check
+
+The above conditions constitute the most complex scenario we have available
+currently. Simpler scenarios follow the same flow as this one, but with less
+steps.
+
+## Old <a name="s-p-c-example-walkthrough-old"></a>
+
+1. Detect companions from PR description
+  - 1.1. Detect Polkadot companion
+    - 1.1.1. Clone Polkadot companion
+    - 1.1.2. Merge master into Polkadot companion
+  - 1.2. Detect Cumulus PR
+    - 1.2.1. Clone Cumulus companion
+    - 1.2.2. Merge master into Cumulus companion
+2. By this point we've either cloned the dependents' repositories from the
+  companion PRs or the default branches in case companions aren't found
+3. Patch the dependencies into the dependents
+  - 3.1. Patch Substrate into Polkadot
+  - 3.2. Patch Polkadot into Cumulus
+4. Run `cargo check`
+
+## New <a name="s-p-c-example-walkthrough-new"></a>
+
+1. Detect companions from PR description
+  - 1.1. Detect Polkadot companion
+    - 1.1.1. Clone Polkadot companion
+    - 1.1.2. Merge master into Polkadot companion
+  - 1.2. Detect Cumulus PR
+    - 1.2.1. Clone Cumulus companion
+    - 1.2.2. Merge master into Cumulus companion
+2. By this point we've either cloned the dependents' repositories by companion
+  PRs or the default branches in case companions aren't found
+3. [NEW] Start branch for the dependent's patched code (which will be later
+  pushed to GitLab)
+4. [CHANGED] Patch the dependencies into the dependents
+  ([example](https://gitlab.parity.io/parity/mirrors/cumulus/-/commits/cbs-145-PR11765-CMP1408))
+  - 4.1. Create commit for Substrate
+  - 4.2. Patch Substrate (commit from Step 4.1) into Polkadot
+  - 4.3. Create commit for Polkadot
+  - 4.4. Patch Polkadot (commit from Step 4.3) into Cumulus
+  - 4.4. Create commit for Cumulus
+5. [NEW] Push the patched branch to GitLab and create a pipeline for it
+  ([example](https://gitlab.parity.io/parity/mirrors/cumulus/-/pipelines/204815))
+6. [NEW] Wait for the created pipeline to finish
+  - 6.1. In case the pipeline succeeds, save the check's data to Redis so that it
+  can be leveraged to potentially skip the companion's pipelines after they're
+  merged
+  ([example](https://gitlab.parity.io/parity/mirrors/cumulus/-/jobs/1699311/artifacts/browse/artifacts/cbs/passed-jobs)).
+7. [NEW] The job succeeds in case the the created pipeline succeeded, otherwise
+  it fails
+
+## Aftermath <a name="s-p-c-example-aftermath"></a>
+
+Continuing from Step 6.1 of [the new walkthrough](#s-p-c-walkthrough-new), what
+happens after the dependents' pipelines succeed? The answer is that their
+corresponding job on Substrate, which created the pipeline, will succeed, which
+leads into the Substrate PR becoming ready to merge. After that, if we say `bot
+merge` on the Substrate PR:
+
+1. Substrate PR is merged
+2. A commit is pushed to update the companion's reference to the master of
+  Substrate, **which makes CI run again**
+
+Note that we've already run the companion's CI once during the Substrate
+pipeline, in Step 5 of [the new walkthrough](#s-p-c-walkthrough-new). For that
+reason it's desirable to rely on heuristics for *potentially* avoiding a second
+redundant run of the pipeline in case the source code resulting from the
+patching procedure remains the same after the companion is updated. It's
+important to emphasize that this idea is an **optimization** and not essential
+to the quality or functionality of the check.
+
+Because the dependencies' master HEAD SHA changes after the dependencies' PRs
+are merged into master, we're unable to rely on a straightforward commit SHA
+comparison based on the companions' updated Cargo.lock references. For this
+reason the heuristics for skipping the pipeline should rely on file contents
+rather than the referenced commit SHAs.
+
+# Setup <a name="setup"></a>
+
+Each dependent will require a GitLab Access Token, to be provided through
+`--gitlab_dependent_token`, with the following scopes:
+
+- `write_repository` so that the dependency's job is able push the patched
+  branch before creating the dependent's pipeline
+- `api` so that the dependency's job can create pipelines
+
+This token should have access to the repositories where the branches will be
+pushed to, i.e. the dependent's repositories.
+
+We recommend the following procedures for the token
+
+- Create it only for the repositories in which the token needs to be used, i.e.
+  one per project instead of one per group
+- Create it with the minimal role which is able to push branches to
+  the repository where it's used; as of this writing it's the `Developer` role.
+- Restrict pushes to important branches in the project to the `Maintainer` role
+  such that the `Developer` token won't be able to push to them.
+
+# Future work <a name="future-work"></a>
+
+- Take care of TODOs in the code
+- Improve failure awareness for the pipeline skipping optimizations, as it can
+  fail for the wrong reasons
+- Design the integration of this approach with pre-merge pipelines
+  - Is it worthwhile to do this?
+    https://forum.parity.io/t/companion-build-system-cbs-vs-cargo-unleash-development-wise/1041
+    might be of interest to this question

--- a/docs/dependent-check.md
+++ b/docs/dependent-check.md
@@ -1,6 +1,6 @@
 # Companion Build System Dependent Check V2
 
-See the example PRs for a demonstration: https://github.com/paritytech/substrate/pull/11765
+**Demonstrations**
 
 Cumulus integration
   - check-dependent-cumulus: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1701832


### PR DESCRIPTION
# Introduction

Refer to https://github.com/joao-paulo-parity/pipeline-scripts/blob/cbs/docs/dependent-check.md for a rendered overview on the changes proposed here.

# Demonstrations

Substrate -> Cumulus integration
  - check-dependent-cumulus: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1701832
  - Patched branch: https://gitlab.parity.io/parity/mirrors/cumulus/-/commits/3f68bccfbbc22a5b1ef7d047739da784b6ddf4c2/
  - Pipeline: https://gitlab.parity.io/parity/mirrors/cumulus/-/pipelines/204815

Subtrate -> Polkadot integration
  - check-dependent-polkadot: https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1701831
  - Patched branch: https://gitlab.parity.io/parity/mirrors/polkadot/-/commits/52f1f7a0803dd85b52cdce14ad30f8943b3f4f59/
  - Pipeline: https://gitlab.parity.io/parity/mirrors/polkadot/-/pipelines/204813

# Release strategy

It only makes sense to merge this PR **simultaneously** with

- https://github.com/paritytech/substrate/pull/11765
- https://github.com/paritytech/polkadot/pull/5713
- https://github.com/paritytech/cumulus/pull/1408

I've left the PRs above ready to be merged aside from the `temporary:` commit on each, which is just for testing purposes and should be reverted once it's time to go forward with this PR.

Some considerations to be had before merging this:

- Given that I'll be unavailable starting from this Friday (Jul 29) I advise that we only go through with this feature once more maintainers will deeply understand what it's doing, as the Companion Build System as a whole is inherently complex. To me it doesn't make sense to have this feature if no one knows how to maintain it.
- We should consider if it's worthwhile to rewrite the script in another language (#21) if the current implementation is deemed too complex due to it being in Bash. This work is regardless relevant in that it shows the decision-making behind the steps needed to achieve the feature.