### PR TITLE
Just pass a folder to `benchmark pallet --output`

### DIFF
--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -94,23 +94,17 @@ bench_pallet() {
       fi
       local weights_dir="./runtime/${runtime_dir}/src/weights"
 
-      local output_file=""
-      if [[ $pallet == *"::"* ]]; then
-        # translates e.g. "pallet_foo::bar" to "pallet_foo_bar"
-        output_file="${pallet//::/_}.rs"
-      fi
-
       case "$kind" in
         runtime)
           args+=(
             --header=./file_header.txt
-            --output="${weights_dir}/${output_file}"
+            --output="${weights_dir}/"
           )
         ;;
         xcm)
           args+=(
             --template=./xcm/pallet-xcm-benchmarks/template.hbs
-            --output="${weights_dir}/xcm/${output_file}"
+            --output="${weights_dir}/xcm/"
           )
         ;;
         *)
@@ -132,23 +126,17 @@ bench_pallet() {
         --header=./file_header.txt
       )
 
-      local output_file=""
-      if [[ $pallet == *"::"* ]]; then
-        # translates e.g. "pallet_foo::bar" to "pallet_foo_bar"
-        output_file="${pallet//::/_}.rs"
-      fi
-
       case "$kind" in
         pallet)
           args+=(
-            --output="./parachains/runtimes/$chain_type/$runtime/src/weights/${output_file}"
+            --output="./parachains/runtimes/$chain_type/$runtime/src/weights/"
           )
         ;;
         xcm)
           mkdir -p "./parachains/runtimes/$chain_type/$runtime/src/weights/xcm"
           args+=(
             --template=./templates/xcm-bench-template.hbs
-            --output="./parachains/runtimes/$chain_type/$runtime/src/weights/xcm/${output_file}"
+            --output="./parachains/runtimes/$chain_type/$runtime/src/weights/xcm/"
           )
         ;;
         *)


### PR DESCRIPTION
Follow up for https://github.com/paritytech/substrate/pull/12332  
Changes for pallet benchmarking:
- Just pass the folder name to `--output`. FRAME should now generate a filename without `::` in it. This prevents multiple instance results being written to the same file, hence enabling instance benchmarking.

Is there a staging deployment or do we just pray that it works after merge?