### PR TITLE
Import some scripts from other repositories

### DIFF
--- a/check-each-crate.sh
+++ b/check-each-crate.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+## A script that checks each workspace crate individually.
+## It's relevant to check workspace crates individually because otherwise their compilation problems
+## due to feature misconfigurations won't be caught, as exemplified by
+## https://github.com/paritytech/substrate/issues/12705
+
+set -Eeu -o pipefail
+shopt -s inherit_errexit
+
+set -vx
+
+target_group="$1"
+groups_total="$2"
+
+readarray -t workspace_crates < <(\
+  cargo tree --workspace --depth 0 --prefix none |
+  awk '{ if (length($1) == 0 || substr($1, 1, 1) == "[") { skip } else { print $1 } }' |
+  sort |
+  uniq
+)
+
+crates_total=${#workspace_crates[*]}
+if [ "$crates_total" -lt 1 ]; then
+  >&2 echo "No crates detected for $PWD"
+  exit 1
+fi
+
+if [ "$crates_total" -lt "$groups_total" ]; then
+  # `crates_total / groups_total` would result in 0, so round it up to 1
+  crates_per_group=1
+else
+  # We add `crates_total % groups_total > 0` (which evaluates to 1 in case there's a remainder for
+  # `crates_total % groups_total`) to round UP `crates_total / groups_total` 's
+  # potentially-fractional result to the nearest integer. Doing that ensures that we'll not miss any
+  # crate in case `crates_total / groups_total` would normally result in a fractional number, since
+  # in those cases Bash would round DOWN the result to the nearest integer. For example, if
+  # `crates_total = 5` and `groups_total = 2`, then `crates_total / groups_total` would round down
+  # to 2; since the loop below would then step by 2, we'd miss the 5th crate.
+  crates_per_group=$(( (crates_total / groups_total) + (crates_total % groups_total > 0) ))
+fi
+
+group=1
+for ((i=0; i < crates_total; i += crates_per_group)); do
+  if [ $group -eq "$target_group" ]; then
+    crates_in_group=("${workspace_crates[@]:$i:$crates_per_group}")
+    echo "crates in the group: ${crates_in_group[*]}" >/dev/null # >/dev/null due to "set -x"
+    for crate in "${crates_in_group[@]}"; do
+      cargo check --locked --release -p "$crate"
+    done
+    break
+  fi
+  group=$(( group + 1 ))
+done

--- a/check-each-crate.sh
+++ b/check-each-crate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## A script that checks each workspace crate individually.
+## A script that runs "cargo check" for each workspace crate individually.
 ## It's relevant to check workspace crates individually because otherwise their compilation problems
 ## due to feature misconfigurations won't be caught, as exemplified by
 ## https://github.com/paritytech/substrate/issues/12705

--- a/create-benchmark-pr.sh
+++ b/create-benchmark-pr.sh
@@ -2,6 +2,9 @@
 
 ## A script that generates a link to the weights comparison tool, then creates a
 ## PR with the generated link in its description.
+## Its usage started in Cumulus to create a PR for updating weights generated from CI jobs:
+## https://github.com/paritytech/cumulus/blob/e4855e352f972f59a2d5941d7bce2d5174ab34ee/scripts/ci/gitlab/pipeline/benchmarks.yml#L31
+## See https://github.com/paritytech/cumulus/pull/1789 for an example of using it.
 
 set -Eeu -o pipefail
 shopt -s inherit_errexit

--- a/create-benchmark-pr.sh
+++ b/create-benchmark-pr.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+## A script that generates a link to the weights comparison tool, then creates a
+## PR with the generated link in its description.
+
+set -Eeu -o pipefail
+shopt -s inherit_errexit
+
+PR_TITLE="$1"
+HEAD_REF="$2"
+
+ORG="{ORG:-paritytech}"
+REPO="$CI_PROJECT_NAME"
+BASE_REF="$CI_COMMIT_BRANCH"
+# Change threshold in %. Bigger values excludes the small changes.
+THRESHOLD=${THRESHOLD:-30}
+
+WEIGHTS_COMPARISON_URL_PARTS=(
+  "https://weights.tasty.limo/compare?"
+  "repo=$REPO&"
+  "threshold=$THRESHOLD&"
+  "path_pattern=**%2Fweights%2F*.rs&"
+  "method=guess-worst&"
+  "ignore_errors=true&"
+  "unit=time&"
+  "old=$BASE_REF&"
+  "new=$HEAD_REF"
+)
+printf -v WEIGHTS_COMPARISON_URL %s "${WEIGHTS_COMPARISON_URL_PARTS[@]}"
+
+PAYLOAD="$(jq -n \
+  --arg title "$PR_TITLE" \
+  --arg body "
+This PR is generated automatically by CI.
+
+Compare the weights with \`$BASE_REF\`: $WEIGHTS_COMPARISON_URL
+
+- [ ] Backport to master and node release branch once merged
+" \
+  --arg base "$BASE_REF" \
+  --arg head "$HEAD_REF" \
+  '{
+      title: $title,
+      body: $body,
+      head: $head,
+      base: $base
+   }'
+)"
+
+echo "PAYLOAD: $PAYLOAD"
+
+curl \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -X POST \
+  -d "$PAYLOAD" \
+  "https://api.github.com/repos/$ORG/$REPO/pulls"


### PR DESCRIPTION
Some scripts such as https://github.com/paritytech/substrate/blob/master/scripts/ci/gitlab/check-each-crate.sh and https://github.com/paritytech/cumulus/blob/master/scripts/ci/create-benchmark-pr.sh can useful for many repositories, so it's better to host them here.

I can adapt the Substrate's script usage within Substrate, after this PR is merged, through https://github.com/paritytech/substrate/pull/12768. I don't intend to open a PR for the Cumulus script right now, but a ticket can be created for that.