### PR TITLE
Set WASM_BUILD_WORKSPACE_HINT before cargo check

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -433,6 +433,7 @@ patch_and_check_dependent() {
   # would not yet how be how it should become after all merges are finished.
   match_dependent_crates "$dependent"
 
+  export WASM_WORKSPACE_BUILD_HINT="$PWD"
   eval "${COMPANION_CHECK_COMMAND:-cargo check --all-targets --workspace}"
 
   popd >/dev/null


### PR DESCRIPTION
A job can set it's own WASM_BUILD_WORKSPACE_HINT as per https://github.com/paritytech/substrate/pull/12816, so we need to correct it before running `cargo check` for the companion.

This change shouldn't break the existing behavior, but I think it's good to wait for @bkchr 's input to be extra sure.