### PR TITLE
remove --locked and ignore committing Cargo.* files

### DIFF
--- a/bench-bot-run.sh
+++ b/bench-bot-run.sh
@@ -19,6 +19,11 @@ echo "Repo: $repository"
 cargo_run() {
   echo "Running $cargo_run_benchmarks" "${args[@]}"
 
+  # if not patched with PATCH_something=123 then use --locked
+  if [[ -z "${BENCH_PATCHED:-}" ]]; then
+    cargo_run_benchmarks+=" --locked"
+  fi
+
   $cargo_run_benchmarks "${args[@]}"
 }
 

--- a/bench-bot-run.sh
+++ b/bench-bot-run.sh
@@ -8,7 +8,7 @@ shopt -s inherit_errexit
 . "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 . "$(dirname "${BASH_SOURCE[0]}")/cmd_runner.sh"
 
-cargo_run_benchmarks="cargo run --locked --quiet --profile=production"
+cargo_run_benchmarks="cargo run --quiet --profile=production"
 current_folder="$(basename "$PWD")"
 
 get_arg optional --repo "$@"

--- a/bench-bot.sh
+++ b/bench-bot.sh
@@ -64,6 +64,11 @@ main() {
 
   # Commits the weights and pushes it
   git add .
+
+  # instead of using `cargo run --locked`, we allow the Cargo files to be updated
+  # but avoid committing them. It is so `cmd_runner_apply_patches` can work
+  git restore --staged Cargo.*
+
   git commit -m "$COMMIT_MESSAGE"
 
   # Push the results to the target branch

--- a/cmd_runner.sh
+++ b/cmd_runner.sh
@@ -43,12 +43,16 @@ cmd_runner_apply_patches() {
 
   local repositories_dir=".git/cmd-runner-patch"
   tmp_dirs+=("$repositories_dir")
+  unset BENCH_PATCHED
 
   while IFS= read -r line; do
     if ! [[ "$line" =~ ^PATCH_([^=]+)=(.*)$ ]]; then
       continue
     fi
     echo "Matched environment variable for patching: $line"
+
+    # used later to decide whether to use "--locked" flag for `cargo run`
+    export BENCH_PATCHED=1
 
     local repository="${BASH_REMATCH[1]}"
     local branch="${BASH_REMATCH[2]}"


### PR DESCRIPTION
`/cmd queue -v PATCH_substrate=tmp-oty-debug-bench-bot-revert -c bench-bot $ runtime polkadot-dev pallet_bounties`
leads to 
```
error: the lock file /var/lib/gitlab-runner/builds/zyw4fam_/0/parity/mirrors/polkadot/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
+ cleanup
+ exit_code=101
+ git remote remove github
+ :
+ rm -rf .git/cmd-runner-patch .git/cmd-runner-patch/substrate
```

https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/2111148

So we revert https://github.com/paritytech/pipeline-scripts/commit/9ecc0607cb85b29301ab4cdfcb02a2fe37bbbf9d adding --locked, but ignore committing Cargo.lock and Cargo.toml files to avoid unwanted cargo updates