### PR TITLE
Update all references in Cargo.lock for patched crates

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -220,9 +220,9 @@ process_pr_description_line() {
       return
     fi
 
-    # if [ "$mergeable" != "true" ]; then
-    #   die "Github API says $repo#$pr_number is not mergeable"
-    # fi
+    if [ "$mergeable" != "true" ]; then
+      die "Github API says $repo#$pr_number is not mergeable"
+    fi
 
     companions+=("$repo")
 

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -220,9 +220,9 @@ process_pr_description_line() {
       return
     fi
 
-    if [ "$mergeable" != "true" ]; then
-      die "Github API says $repo#$pr_number is not mergeable"
-    fi
+    # if [ "$mergeable" != "true" ]; then
+    #   die "Github API says $repo#$pr_number is not mergeable"
+    # fi
 
     companions+=("$repo")
 


### PR DESCRIPTION
Works around https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/2115137#L1544

Comparing https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/2115137#L1544, which failed to compile `polkadot-node-subsystem-test-helpers` with errors such as

```
error[E0053]: method `authority_set_proof` has an incompatible type for trait
    --> /builds/parity/mirrors/substrate/extra_dependencies/polkadot/runtime/rococo/src/lib.rs:1882:31
     |
1882 |         fn authority_set_proof() -> beefy_primitives::mmr::BeefyAuthoritySet<Hash> {
     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |                                     |
     |                                     expected struct `sp_beefy::mmr::BeefyAuthoritySet`, found struct `BeefyAuthoritySet`
     |                                     help: change the output type to match the trait: `sp_beefy::mmr::BeefyAuthoritySet<H256>`
     |
     = note: expected fn pointer `fn() -> sp_beefy::mmr::BeefyAuthoritySet<H256>`
                found fn pointer `fn() -> BeefyAuthoritySet<H256>`
```

with https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/2116743#L1811, which got past that point, I think that the fix is effective.

ref https://github.com/paritytech/substrate/pull/12837#issuecomment-1336975421