### PR TITLE
Correct the variable name to WASM_BUILD_WORKSPACE_HINT

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -450,7 +450,7 @@ patch_and_check_dependent() {
   # would not yet how be how it should become after all merges are finished.
   match_dependent_crates "$dependent"
 
-  export WASM_WORKSPACE_BUILD_HINT="$PWD"
+  export WASM_BUILD_WORKSPACE_HINT="$PWD"
   eval "${COMPANION_CHECK_COMMAND:-cargo check --all-targets --workspace}"
 
   popd >/dev/null


### PR DESCRIPTION
I used the wrong variable name in https://github.com/paritytech/pipeline-scripts/pull/87. Should've copy-and-pasted. Sorry.