### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @paritytech/ci
-* @paritytech/opstooling
+* @paritytech/ci @paritytech/opstooling


### PR DESCRIPTION
The line `* @paritytech/opstooling` was overriding the line `* @paritytech/ci` because it appeared later in the file, which meant that paritytech/ci wasn't actually a code owner. The solution is to put both teams in the same line for the effect of `OR`: require an approval from paritytech/ci `OR` paritytech/opstooling.

For syntax reference and an example see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file