### PR TITLE
Allow PRs to have more than 100 commits for check_dependent_project.sh

### DIFF
--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -629,6 +629,7 @@ main() {
     # Since master's HEAD is being merged here, at the start the dependency chain,
     # the same has to be done for all the companions because they might have
     # accompanying changes for the code being brought in.
+    git fetch --force origin master
     merge_remote_ref origin master "Merge master into $this_repo#$CI_COMMIT_REF_NAME"
   fi
 

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -61,14 +61,17 @@ merge_remote_ref() {
   local message="$3"
 
   git show-ref "$remote"/"$ref"
-  if ! \
-    git merge "$remote"/"$ref" \
+
+  local merge_exit_code
+
+  git merge \
+    "$remote"/"$ref" \
       --verbose \
       --no-edit \
-      -m "$message"
-  then
-    local exit_code=$?
+      -m "$message" \
+    || merge_exit_code=$?
 
+  if [ "${merge_exit_code:-0}" != 0 ]; then
     echo "
 Failed to merge $ref into $repo#$pr_number after fetching its last $merge_ancestor_max_depth commits.
 
@@ -80,8 +83,7 @@ OR
 
 - $repo#$pr_number is ahead of master by more than $merge_ancestor_max_depth commits. To solve this you can merge master into the branch locally and push.
 "
-
-    exit $exit_code
+    exit $merge_exit_code
   fi
 }
 

--- a/check_dependent_project.sh
+++ b/check_dependent_project.sh
@@ -477,9 +477,9 @@ patch_and_check_dependent() {
 }
 
 main() {
-  local this_pr
+  local this_pr_number
   if [[ "$CI_COMMIT_REF_NAME" =~ ^[[:digit:]]+$ ]]; then
-    this_pr="$CI_COMMIT_REF_NAME"
+    this_pr_number="$CI_COMMIT_REF_NAME"
   else
     die "\"$CI_COMMIT_REF_NAME\" was not recognized as a pull request ref"
   fi
@@ -492,7 +492,7 @@ main() {
   # process_pr_description calls itself for each companion in the description on
   # each detected companion PR, effectively considering all companion references
   # on all PRs
-  process_pr_description "$this_repo" "$this_pr"
+  process_pr_description "$this_repo" "$this_pr_number"
 
   # This PR might be targetting a custom ref (i.e. not master) through companion
   # overrides from --companion-overrides or the PR's description, in which case
@@ -645,8 +645,8 @@ main() {
       origin \
       master \
       "$this_repo" \
-      "$this_pr" \
-      "Merge master into $this_repo#$this_pr"
+      "$this_pr_number" \
+      "Merge master into $this_repo#$this_pr_number"
   fi
 
   discover_our_crates


### PR DESCRIPTION
**Problem**: PRs (such as https://github.com/paritytech/substrate/pull/12924) can have more than 100 commits, but [the script only clones the last 100 commits](https://github.com/paritytech/pipeline-scripts/blob/86c3c22c8fdf5453f8f1f43c610b5d111755bfb6/check_dependent_project.sh#L231) and thus [it might not be able find the merge ancestor](https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/2264530#L185) for `git merge master` to work.

**Solution**:

- Increase the commit limit for PRs
- Provide a helpful error message in case a problem happens