### PR TITLE
Update diener for update_substrate_template

### DIFF
--- a/update_substrate_template.sh
+++ b/update_substrate_template.sh
@@ -23,6 +23,14 @@
 
 set -eu -o pipefail
 
+# TODO: manual diener installation should be removed after
+# https://github.com/paritytech/scripts/pull/506 is merged and the ci-linux
+# image is rebuilt
+mkdir -p "$HOME/.cargo-bin"
+export PATH="$HOME/.cargo-bin/bin:$PATH"
+cargo install diener --root "$HOME/.cargo-bin" --version 0.4.6
+diener --version
+
 . "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 # substrate-parachain-template or substrate-node-template


### PR DESCRIPTION
This can solve https://github.com/paritytech/pipeline-scripts/issues/97 in the meantime if you do not wish to wait until https://github.com/paritytech/scripts/pull/506 is merged and the `ci-linux` image is rebuilt.

close #97